### PR TITLE
list structure fields parse as empty lists when field is missing

### DIFF
--- a/blueprints/base/values.go
+++ b/blueprints/base/values.go
@@ -14,6 +14,7 @@ const (
 var (
 	Nil          = cg.V("nil")
 	IPLDKindType = &cg.GoTypeRef{PkgPath: IPLDDatamodelPkg, TypeName: "Kind"}
+	IPLDNull     = &cg.GoTypeRef{PkgPath: IPLDDatamodelPkg, TypeName: "Null"}
 	// IPLD kind values
 	IPLDKindInvalid = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Invalid"}
 	IPLDKindBool    = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Bool"}
@@ -45,6 +46,7 @@ var (
 	EdelweissErrNotFound = &cg.GoRef{PkgPath: EdelweissValuesPkg, Name: "ErrNotFound"}
 	EdelweissString      = &cg.GoRef{PkgPath: EdelweissValuesPkg, Name: "String"}
 	EdelweissInt         = &cg.GoRef{PkgPath: EdelweissValuesPkg, Name: "Int"}
+	EdelweissParseFunc   = &cg.GoRef{PkgPath: EdelweissValuesPkg, Name: "ParseFunc"}
 )
 
 var (

--- a/blueprints/base/values.go
+++ b/blueprints/base/values.go
@@ -17,6 +17,7 @@ var (
 	IPLDNull     = &cg.GoTypeRef{PkgPath: IPLDDatamodelPkg, TypeName: "Null"}
 	// IPLD kind values
 	IPLDKindInvalid = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Invalid"}
+	IPLDKindNull    = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Null"}
 	IPLDKindBool    = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Bool"}
 	IPLDKindInt     = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Int"}
 	IPLDKindFloat   = &cg.GoRef{PkgPath: IPLDDatamodelPkg, Name: "Kind_Float"}

--- a/blueprints/values/list.go
+++ b/blueprints/values/list.go
@@ -40,6 +40,7 @@ func (x *GoListImpl) GoDef() cg.Blueprint {
 		"Node":            base.IPLDNodeType,
 		"KindType":        base.IPLDKindType,
 		"KindList":        base.IPLDKindList,
+		"KindNull":        base.IPLDKindNull,
 		"KindString":      base.IPLDKindString,
 		"KindInt":         base.IPLDKindInt,
 		"ErrNA":           base.EdelweissErrNA,
@@ -64,6 +65,10 @@ func (v {{.Type}}) Node() {{.Node}} {
 }
 
 func (v *{{.Type}}) Parse(n {{.Node}}) error {
+	if n.Kind() == {{.KindNull}} {
+		*v = nil
+		return nil
+	}
 	if n.Kind() != {{.KindList}} {
 		return {{.ErrNA}}
 	} else {

--- a/blueprints/values/structure.go
+++ b/blueprints/values/structure.go
@@ -41,6 +41,7 @@ func (x *GoStructureImpl) GoDef() cg.Blueprint {
 			"FieldNameString":  cg.StringLiteral(fields[i].Name),
 			"FieldType":        x.Lookup.LookupDepGoRef(fields[i].Type),
 			"EdelweissString":  base.EdelweissString,
+			"Errorf":           base.Errorf,
 		}
 	}
 	// build field declarations
@@ -53,14 +54,22 @@ func (x *GoStructureImpl) GoDef() cg.Blueprint {
 	}
 	// build field parse cases
 	fieldParseCases := make(cg.BlueSlice, len(fields))
+	fieldParseMapCases := make(cg.BlueSlice, len(fields))
 	for i := range fields {
+		fieldParseMapCases[i] = cg.T{
+			Data: fieldData[i],
+			Src: "		{{.FieldNameString}}: x.{{.FieldName}}.Parse,\n",
+		}
 		fieldParseCases[i] = cg.T{
 			Data: fieldData[i],
 			Src: `		case {{.FieldNameString}}:
+			if _, notParsed := fieldMap[{{.FieldNameString}}]; !notParsed {
+				return {{.Errorf}}("field %s already parsed", {{.FieldNameString}})
+			}
 			if err := x.{{.FieldName}}.Parse(vn); err != nil {
 				return err
 			}
-			nfields++
+			delete(fieldMap, {{.FieldNameString}})
 `,
 		}
 	}
@@ -106,23 +115,26 @@ func (x *GoStructureImpl) GoDef() cg.Blueprint {
 	}
 	// build type definition
 	data := cg.BlueMap{
-		"Type":            x.Ref,
-		"Node":            base.IPLDNodeType,
-		"KindType":        base.IPLDKindType,
-		"KindMap":         base.IPLDKindMap,
-		"KindString":      base.IPLDKindString,
-		"KindInt":         base.IPLDKindInt,
-		"ErrNA":           base.EdelweissErrNA,
-		"PathSegment":     base.IPLDPathSegment,
-		"MapIterator":     base.IPLDMapIteratorType,
-		"ListIterator":    base.IPLDListIteratorType,
-		"Link":            base.IPLDLinkType,
-		"NodePrototype":   base.IPLDNodePrototypeType,
-		"Length":          cg.IntLiteral(len(fields)),
-		"EdelweissString": base.EdelweissString,
-		"Errorf":          base.Errorf,
+		"Type":               x.Ref,
+		"Node":               base.IPLDNodeType,
+		"Null":               base.IPLDNull,
+		"KindType":           base.IPLDKindType,
+		"KindMap":            base.IPLDKindMap,
+		"KindString":         base.IPLDKindString,
+		"KindInt":            base.IPLDKindInt,
+		"ErrNA":              base.EdelweissErrNA,
+		"PathSegment":        base.IPLDPathSegment,
+		"MapIterator":        base.IPLDMapIteratorType,
+		"ListIterator":       base.IPLDListIteratorType,
+		"Link":               base.IPLDLinkType,
+		"NodePrototype":      base.IPLDNodePrototypeType,
+		"Length":             cg.IntLiteral(len(fields)),
+		"EdelweissString":    base.EdelweissString,
+		"EdelweissParseFunc": base.EdelweissParseFunc,
+		"Errorf":             base.Errorf,
 		//
 		"FieldDecls":                fieldDecls,
+		"FieldParseMapCases":        fieldParseMapCases,
 		"FieldParseCases":           fieldParseCases,
 		"FieldNextCases":            fieldNextCases,
 		"FieldLookupByStringCases":  fieldLookupByStringCases,
@@ -147,7 +159,9 @@ func (x *{{.Type}}) Parse(n {{.Node}}) error {
 		return {{.ErrNA}}
 	}
 	iter := n.MapIterator()
-	nfields := 0
+	fieldMap := map[string]{{.EdelweissParseFunc}}{
+		{{range .FieldParseMapCases}}{{.}}{{end}}
+	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -162,11 +176,12 @@ func (x *{{.Type}}) Parse(n {{.Node}}) error {
 			}
 		}
 	}
-	if nfields != {{.Length}} {
-		return {{.ErrNA}}
-	} else {
-		return nil
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse({{.Null}}); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type {{.Type}}_MapIterator struct {

--- a/test/dagjson_test.go
+++ b/test/dagjson_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/ipld/edelweiss/defs"
+)
+
+// TestDAGJSONStructureEmptyListAtRunTime tests that a missing list field decodes as an empty list.
+func TestDAGJSONStructureEmptyListAtRunTime(t *testing.T) {
+	defs := []defs.Defs{
+		{defs.Named{
+			Name: "UserStructure",
+			Type: defs.Structure{
+				Fields: defs.Fields{
+					defs.Field{Name: "F", Type: defs.List{Element: defs.Int{}}},
+				},
+			},
+		}},
+	}
+	testSrc := `
+	var x1 UserStructure
+	var x2 UserStructure
+	buf := []byte("{}") // field is missing in encoding
+	n, err := ipld.Decode(buf, dagjson.Decode)
+	if err != nil {
+		t.Fatalf("decoding (%v)", err)
+	}
+	if err = x2.Parse(n); err != nil {
+		t.Fatalf("parsing (%v)", err)
+	}
+	if !ipld.DeepEqual(x1, x2) {
+		t.Errorf("ipld values are not equal")
+	}
+`
+	for _, d := range defs {
+		RunSingleGenTest(t, d, testSrc)
+	}
+}

--- a/test/harness.go
+++ b/test/harness.go
@@ -36,7 +36,7 @@ module test
 go 1.16
 
 require (
-	github.com/ipld/edelweiss 8a7866e4dcfbf54b11eb0a64194b27e74c0b33ef
+	github.com/ipld/edelweiss 04fefef7007b598f1b46bb1618400c9fa81fd3a9
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/ipfs/go-cid v0.0.4
 )

--- a/test/values_test.go
+++ b/test/values_test.go
@@ -198,39 +198,39 @@ func TestMapAtRunTime(t *testing.T) {
 
 // IPLD DAGJSON encoding does not support maps with non-string keys.
 // This can be remedied on the Edelweiss side by using encoding non-string key maps into a list of pairs repn.
-func _TestNonStringMapAtRunTime(t *testing.T) {
-	defs := []defs.Defs{
-		{defs.Named{
-			Name: "UserMap",
-			Type: defs.Map{Key: defs.Float{}, Value: defs.Int{}},
-		}},
-	}
-	testSrc := `
-	var x1 UserMap = UserMap{
-		{Key: 123.456, Value: 1},
-		{Key: 456.789, Value: 2},
-	}
-	buf, err := ipld.Encode(x1, dagjson.Encode)
-	if err != nil {
-		t.Fatalf("encoding (%v)", err)
-	}
-	fmt.Println(string(buf))
-	var x2 UserMap
-	n, err := ipld.Decode(buf, dagjson.Decode)
-	if err != nil {
-		t.Fatalf("decoding (%v)", err)
-	}
-	if err = x2.Parse(n); err != nil {
-		t.Fatalf("parsing (%v)", err)
-	}
-	if !ipld.DeepEqual(x1, x2) {
-		t.Errorf("ipld values are not equal")
-	}
-`
-	for _, d := range defs {
-		RunSingleGenTest(t, d, testSrc)
-	}
-}
+// func _TestNonStringMapAtRunTime(t *testing.T) {
+// 	defs := []defs.Defs{
+// 		{defs.Named{
+// 			Name: "UserMap",
+// 			Type: defs.Map{Key: defs.Float{}, Value: defs.Int{}},
+// 		}},
+// 	}
+// 	testSrc := `
+// 	var x1 UserMap = UserMap{
+// 		{Key: 123.456, Value: 1},
+// 		{Key: 456.789, Value: 2},
+// 	}
+// 	buf, err := ipld.Encode(x1, dagjson.Encode)
+// 	if err != nil {
+// 		t.Fatalf("encoding (%v)", err)
+// 	}
+// 	fmt.Println(string(buf))
+// 	var x2 UserMap
+// 	n, err := ipld.Decode(buf, dagjson.Decode)
+// 	if err != nil {
+// 		t.Fatalf("decoding (%v)", err)
+// 	}
+// 	if err = x2.Parse(n); err != nil {
+// 		t.Fatalf("parsing (%v)", err)
+// 	}
+// 	if !ipld.DeepEqual(x1, x2) {
+// 		t.Errorf("ipld values are not equal")
+// 	}
+// `
+// 	for _, d := range defs {
+// 		RunSingleGenTest(t, d, testSrc)
+// 	}
+// }
 
 func TestListAtRunTime(t *testing.T) {
 	defs := []defs.Defs{

--- a/values/list.go
+++ b/values/list.go
@@ -30,6 +30,10 @@ func (v List) Node() datamodel.Node {
 }
 
 func (v *List) Parse(n datamodel.Node) error {
+	if n.Kind() == ipld.Kind_Null {
+		*v = nil
+		return nil
+	}
 	if n.Kind() != ipld.Kind_List {
 		return ErrNA
 	} else {

--- a/values/valuetype.go
+++ b/values/valuetype.go
@@ -19,6 +19,8 @@ type Parser interface {
 	Parse(datamodel.Node) error
 }
 
+type ParseFunc func(datamodel.Node) error
+
 var (
 	ErrNA           = fmt.Errorf("n/a")
 	ErrBounds       = fmt.Errorf("index out of bounds")


### PR DESCRIPTION
We treat a missing list field (in the encoding) as an empty list.