### PR TITLE
upgrade service generation to meet IPFS routing API requirements

### DIFF
--- a/blueprints/base/services.go
+++ b/blueprints/base/services.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	cg "github.com/ipld/edelweiss/codegen"
+	"github.com/ipld/edelweiss/services"
 )
 
 var (
@@ -24,4 +25,12 @@ var (
 	IOReader           = &cg.GoRef{PkgPath: "io", Name: "Reader"}
 	IOEOF              = &cg.GoRef{PkgPath: "io", Name: "EOF"}
 	IOErrUnexpectedEOF = &cg.GoRef{PkgPath: "io", Name: "ErrUnexpectedEOF"}
+)
+
+const EdelweissServicesPkg = services.PkgPath
+
+var (
+	EdelweissErrContext = &cg.GoTypeRef{PkgPath: EdelweissServicesPkg, TypeName: "ErrContext"}
+	EdelweissErrProto   = &cg.GoTypeRef{PkgPath: EdelweissServicesPkg, TypeName: "ErrProto"}
+	EdelweissErrService = &cg.GoTypeRef{PkgPath: EdelweissServicesPkg, TypeName: "ErrService"}
 )

--- a/blueprints/base/values.go
+++ b/blueprints/base/values.go
@@ -51,6 +51,7 @@ var (
 )
 
 var (
-	Errorf   = &cg.GoRef{PkgPath: "fmt", Name: "Errorf"}
-	ErrorsIs = &cg.GoRef{PkgPath: "errors", Name: "Is"}
+	Errorf    = &cg.GoRef{PkgPath: "fmt", Name: "Errorf"}
+	ErrorsIs  = &cg.GoRef{PkgPath: "errors", Name: "Is"}
+	ErrorsNew = &cg.GoRef{PkgPath: "errors", Name: "New"}
 )

--- a/blueprints/services/dagjson-over-http/client.go
+++ b/blueprints/services/dagjson-over-http/client.go
@@ -217,7 +217,7 @@ func (c *{{.Type}}) {{.AsyncMethodDecl}} {
 	q := {{.URLValues}}{}
 	q.Set("q", string(buf))
 	u.RawQuery = q.Encode()
-	httpReq, err := {{.HTTPNewRequestWithContext}}(ctx, "GET", u.String(), {{.BytesNewReader}}(buf))
+	httpReq, err := {{.HTTPNewRequestWithContext}}(ctx, "POST", u.String(), {{.BytesNewReader}}(buf))
 	if err != nil {
 		return nil, err
 	}

--- a/blueprints/services/dagjson-over-http/server.go
+++ b/blueprints/services/dagjson-over-http/server.go
@@ -37,6 +37,9 @@ func (x GoServerImpl) GoDef() cg.Blueprint {
 	methodDecls := make(cg.BlueSlice, len(methods))
 	methodCases := make(cg.BlueSlice, len(methods))
 	for i, m := range methods {
+		if m.Name == x.Def.Identify.Name {
+			continue
+		}
 		// async result type is defined by the client codegen
 		asyncResultRef := &cg.GoTypeRef{PkgPath: x.Ref.PkgPath, TypeName: x.Ref.TypeName + "_" + m.Name + "_AsyncResult"}
 		bmDecl := cg.BlueMap{
@@ -103,6 +106,10 @@ func (x GoServerImpl) GoDef() cg.Blueprint {
 		"CallEnvelope": x.Lookup.LookupDepGoRef(x.Def.CallEnvelope),
 		"MethodDecls":  methodDecls,
 		"MethodCases":  methodCases,
+		//
+		"IdentifyMethodName":   cg.V(x.Def.Identify.Name),
+		"IdentifyMethodArg":    x.Lookup.LookupDepGoRef(x.Def.Identify.Type.Arg),
+		"IdentifyMethodReturn": x.Lookup.LookupDepGoRef(x.Def.Identify.Type.Return),
 	}
 	return cg.T{Data: data, Src: goServerTemplate}
 }

--- a/codegen/blueprint.go
+++ b/codegen/blueprint.go
@@ -102,7 +102,7 @@ func flattenBlueprint(ctx GoFileContext, b Blueprint) (Blueprint, error) {
 		}
 		return V(buf.String()), nil
 	}
-	panic("not a blue value")
+	panic(fmt.Sprintf("not a blue value: %#v", b))
 }
 
 func flattenBlueMap(ctx GoFileContext, bm BlueMap) (BlueMap, error) {

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -237,8 +237,9 @@ func TestServiceAtCompileTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = goFile.Generate()
+	buf, err := goFile.Generate()
 	if err != nil {
 		t.Fatal(err)
 	}
+	println(string(buf))
 }

--- a/compile/plan.go
+++ b/compile/plan.go
@@ -39,15 +39,16 @@ func (p *genPlan) Plan() []typePlan {
 	return p.plan
 }
 
-func (p *genPlan) AddNamed(name string, d plans.Plan) error {
+func (p *genPlan) AddNamed(name string, d plans.Plan) (plans.Ref, error) {
 	if _, ok := p.nameToPlan[name]; ok {
-		return fmt.Errorf("name %s already defined", name)
+		return plans.Ref{}, fmt.Errorf("name %s already defined", name)
 	}
 	goTypeRef := cg.GoTypeRef{PkgPath: p.goPkgPath, TypeName: name}
-	p.planToGo[plans.Ref{Name: name}] = goTypeRef
+	ref := plans.Ref{Name: name}
+	p.planToGo[ref] = goTypeRef
 	p.plan = append(p.plan, typePlan{Name: name, Plan: d, GoRef: goTypeRef})
 	p.nameToPlan[name] = d
-	return nil
+	return ref, nil
 }
 
 func (p *genPlan) AddAnonymous(t plans.Plan) plans.Ref {

--- a/compile/stages.go
+++ b/compile/stages.go
@@ -231,10 +231,16 @@ func provisionService(p *genPlan, named string, s defs.Service) (plans.Plan, err
 		defs.Method{
 			Name: plans.IdentifyName,
 			Type: defs.Fn{
-				Arg: defs.Structure{},
-				Return: defs.Structure{
-					Fields: defs.Fields{
-						defs.Field{Name: "Methods", GoName: "Methods", Type: defs.List{Element: defs.String{}}},
+				Arg: defs.Named{
+					Name: fmt.Sprintf("%s_IdentifyArg", named),
+					Type: defs.Structure{},
+				},
+				Return: defs.Named{
+					Name: fmt.Sprintf("%s_IdentifyResult", named),
+					Type: defs.Structure{
+						Fields: defs.Fields{
+							defs.Field{Name: "Methods", GoName: "Methods", Type: defs.List{Element: defs.String{}}},
+						},
 					},
 				},
 			},

--- a/compile/stages.go
+++ b/compile/stages.go
@@ -237,12 +237,12 @@ func provisionService(p *genPlan, named string, s defs.Service) (plans.Plan, err
 		}
 		fn := plans.Fn{Arg: argRef, Return: returnRef}
 		plan.Methods[i] = plans.Method{Name: m.Name, Type: fn}
-		callCases[i] = plans.Case{Name: m.Name + "Request", Type: argRef}
-		returnCases[i] = plans.Case{Name: m.Name + "Response", Type: returnRef}
+		callCases[i] = plans.Case{Name: m.Name + "Request", GoName: m.Name, Type: argRef}
+		returnCases[i] = plans.Case{Name: m.Name + "Response", GoName: m.Name, Type: returnRef}
 	}
 	errorEnvelope := plans.Structure{
 		Fields: plans.Fields{
-			plans.Field{Name: "Code", Type: plans.String{}},
+			plans.Field{Name: "Code", GoName: "Code", Type: plans.String{}},
 		},
 	}
 	var err error

--- a/examples/gen-routing-api/proto/proto_edelweiss.go
+++ b/examples/gen-routing-api/proto/proto_edelweiss.go
@@ -1,28 +1,635 @@
 package proto
 
-import (
-	pd9 "bytes"
-	pd6 "context"
-	pd8 "errors"
-	pd3 "fmt"
-	pd12 "github.com/ipfs/go-log"
-	pd2 "github.com/ipld/edelweiss/values"
-	pd5 "github.com/ipld/go-ipld-prime"
-	pd7 "github.com/ipld/go-ipld-prime/codec/dagjson"
+import(
 	pd1 "github.com/ipld/go-ipld-prime/datamodel"
-	pd10 "io"
+	pd2 "github.com/ipld/edelweiss/values"
+	pd3 "fmt"
 	pd4 "net/http"
-	pd11 "net/url"
+	pd5 "errors"
+	pd6 "context"
+	pd7 "io"
+	pd8 "github.com/ipld/go-ipld-prime"
+	pd9 "net/url"
+	pd10 "github.com/ipld/go-ipld-prime/codec/dagjson"
+	pd11 "bytes"
+	pd12 "github.com/ipld/edelweiss/services"
+	pd13 "github.com/ipfs/go-log"
 )
 
-// -- protocol type AnonInductive0 --
 
-type AnonInductive0 struct {
-	GetP2PProvide *GetP2PProvideRequest
+// -- protocol type DelegatedRouting_IdentifyArg --
+
+type DelegatedRouting_IdentifyArg struct {
+
 }
 
-func (x *AnonInductive0) Parse(n pd1.Node) error {
-	*x = AnonInductive0{}
+func (x DelegatedRouting_IdentifyArg) Node() pd1.Node {
+	return x
+}
+
+func (x *DelegatedRouting_IdentifyArg) Parse(n pd1.Node) error {
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	fieldMap := map[string]pd2.ParseFunc{
+		
+	}
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+
+				}
+			}
+		}
+	}
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type DelegatedRouting_IdentifyArg_MapIterator struct {
+	i int64
+	s *DelegatedRouting_IdentifyArg
+}
+
+func (x *DelegatedRouting_IdentifyArg_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *DelegatedRouting_IdentifyArg_MapIterator) Done() bool {
+	return x.i + 1 >= 0
+}
+
+func (x DelegatedRouting_IdentifyArg) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x DelegatedRouting_IdentifyArg) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) MapIterator() pd1.MapIterator {
+	return &DelegatedRouting_IdentifyArg_MapIterator{-1, &x}
+}
+
+func (x DelegatedRouting_IdentifyArg) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x DelegatedRouting_IdentifyArg) Length() int64 {
+	return 0
+}
+
+func (x DelegatedRouting_IdentifyArg) IsAbsent() bool {
+	return false
+}
+
+func (x DelegatedRouting_IdentifyArg) IsNull() bool {
+	return false
+}
+
+func (x DelegatedRouting_IdentifyArg) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyArg) Prototype() pd1.NodePrototype {
+	return nil
+}
+
+// -- protocol type AnonList1 --
+
+type AnonList1 []pd2.String
+
+func (v AnonList1) Node() pd1.Node {
+	return v
+}
+
+func (v *AnonList1) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
+	if n.Kind() != pd1.Kind_List {
+		return pd2.ErrNA
+	} else {
+		*v = make(AnonList1, n.Length())
+		iter := n.ListIterator()
+		for !iter.Done() {
+			if i, n, err := iter.Next(); err != nil {
+				return pd2.ErrNA
+			} else if err = (*v)[i].Parse(n); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (AnonList1) Kind() pd1.Kind {
+	return pd1.Kind_List
+}
+
+func (AnonList1) LookupByString(string) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList1) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (v AnonList1) LookupByIndex(i int64) (pd1.Node, error) {
+	if i < 0 || i >= v.Length() {
+		return nil, pd2.ErrBounds
+	} else {
+		return v[i].Node(), nil
+	}
+}
+
+func (v AnonList1) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	if i, err := seg.Index(); err != nil {
+		return nil, pd2.ErrNA
+	} else {
+		return v.LookupByIndex(i)
+	}
+}
+
+func (AnonList1) MapIterator() pd1.MapIterator {
+	return nil
+}
+
+func (v AnonList1) ListIterator() pd1.ListIterator {
+	return &AnonList1_ListIterator{v, 0}
+}
+
+func (v AnonList1) Length() int64 {
+	return int64(len(v))
+}
+
+func (AnonList1) IsAbsent() bool {
+	return false
+}
+
+func (AnonList1) IsNull() bool {
+	return false
+}
+
+func (v AnonList1) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (AnonList1) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList1) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList1) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (AnonList1) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList1) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList1) Prototype() pd1.NodePrototype {
+	return nil // not needed
+}
+
+type AnonList1_ListIterator struct {
+	list AnonList1
+	at   int64
+}
+
+func (iter *AnonList1_ListIterator) Next() (int64, pd1.Node, error) {
+	if iter.Done() {
+		return -1, nil, pd2.ErrBounds
+	}
+	v := iter.list[iter.at]
+	i := int64(iter.at)
+	iter.at++
+	return i, v.Node(), nil
+}
+
+func (iter *AnonList1_ListIterator) Done() bool {
+	return iter.at >= iter.list.Length()
+}
+// -- protocol type DelegatedRouting_IdentifyResult --
+
+type DelegatedRouting_IdentifyResult struct {
+		Methods AnonList1
+
+}
+
+func (x DelegatedRouting_IdentifyResult) Node() pd1.Node {
+	return x
+}
+
+func (x *DelegatedRouting_IdentifyResult) Parse(n pd1.Node) error {
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	fieldMap := map[string]pd2.ParseFunc{
+				"Methods": x.Methods.Parse,
+
+	}
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+			case "Methods":
+			if _, notParsed := fieldMap["Methods"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Methods")
+			}
+			if err := x.Methods.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Methods")
+
+				}
+			}
+		}
+	}
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type DelegatedRouting_IdentifyResult_MapIterator struct {
+	i int64
+	s *DelegatedRouting_IdentifyResult
+}
+
+func (x *DelegatedRouting_IdentifyResult_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+			case 0:
+			return pd2.String("Methods"), x.s.Methods.Node(), nil
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *DelegatedRouting_IdentifyResult_MapIterator) Done() bool {
+	return x.i + 1 >= 1
+}
+
+func (x DelegatedRouting_IdentifyResult) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x DelegatedRouting_IdentifyResult) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+		case "Methods":
+		return x.Methods.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+		case 0:
+		return x.Methods.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "0", "Methods":
+		return x.Methods.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) MapIterator() pd1.MapIterator {
+	return &DelegatedRouting_IdentifyResult_MapIterator{-1, &x}
+}
+
+func (x DelegatedRouting_IdentifyResult) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x DelegatedRouting_IdentifyResult) Length() int64 {
+	return 1
+}
+
+func (x DelegatedRouting_IdentifyResult) IsAbsent() bool {
+	return false
+}
+
+func (x DelegatedRouting_IdentifyResult) IsNull() bool {
+	return false
+}
+
+func (x DelegatedRouting_IdentifyResult) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_IdentifyResult) Prototype() pd1.NodePrototype {
+	return nil
+}
+
+// -- protocol type DelegatedRouting_Error --
+
+type DelegatedRouting_Error struct {
+		Code pd2.String
+
+}
+
+func (x DelegatedRouting_Error) Node() pd1.Node {
+	return x
+}
+
+func (x *DelegatedRouting_Error) Parse(n pd1.Node) error {
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	fieldMap := map[string]pd2.ParseFunc{
+				"Code": x.Code.Parse,
+
+	}
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+			case "Code":
+			if _, notParsed := fieldMap["Code"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Code")
+			}
+			if err := x.Code.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Code")
+
+				}
+			}
+		}
+	}
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type DelegatedRouting_Error_MapIterator struct {
+	i int64
+	s *DelegatedRouting_Error
+}
+
+func (x *DelegatedRouting_Error_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+			case 0:
+			return pd2.String("Code"), x.s.Code.Node(), nil
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *DelegatedRouting_Error_MapIterator) Done() bool {
+	return x.i + 1 >= 1
+}
+
+func (x DelegatedRouting_Error) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x DelegatedRouting_Error) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+		case "Code":
+		return x.Code.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+		case 0:
+		return x.Code.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "0", "Code":
+		return x.Code.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) MapIterator() pd1.MapIterator {
+	return &DelegatedRouting_Error_MapIterator{-1, &x}
+}
+
+func (x DelegatedRouting_Error) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x DelegatedRouting_Error) Length() int64 {
+	return 1
+}
+
+func (x DelegatedRouting_Error) IsAbsent() bool {
+	return false
+}
+
+func (x DelegatedRouting_Error) IsNull() bool {
+	return false
+}
+
+func (x DelegatedRouting_Error) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x DelegatedRouting_Error) Prototype() pd1.NodePrototype {
+	return nil
+}
+
+// -- protocol type AnonInductive4 --
+
+type AnonInductive4 struct {
+		Identify *DelegatedRouting_IdentifyArg
+		GetP2PProvide *GetP2PProvideRequest
+
+}
+
+func (x *AnonInductive4) Parse(n pd1.Node) error {
+	*x = AnonInductive4{}
 	if n.Kind() != pd1.Kind_Map {
 		return pd2.ErrNA
 	}
@@ -36,7 +643,14 @@ func (x *AnonInductive0) Parse(n pd1.Node) error {
 		return pd3.Errorf("inductive map key is not a string")
 	}
 	switch k {
-	case "GetP2PProvide":
+	case "IdentifyRequest":
+		var y DelegatedRouting_IdentifyArg
+		if err := y.Parse(vn); err != nil {
+			return err
+		}
+		x.Identify = &y
+		return nil
+	case "GetP2PProvideRequest":
 		var y GetP2PProvideRequest
 		if err := y.Parse(vn); err != nil {
 			return err
@@ -48,19 +662,21 @@ func (x *AnonInductive0) Parse(n pd1.Node) error {
 	return pd3.Errorf("inductive map has no applicable keys")
 }
 
-type AnonInductive0_MapIterator struct {
+type AnonInductive4_MapIterator struct {
 	done bool
-	s    *AnonInductive0
+	s    *AnonInductive4
 }
 
-func (x *AnonInductive0_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+func (x *AnonInductive4_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	if x.done {
 		return nil, nil, pd2.ErrNA
 	} else {
 		x.done = true
 		switch {
-		case x.s.GetP2PProvide != nil:
-			return pd2.String("GetP2PProvide"), x.s.GetP2PProvide.Node(), nil
+			case x.s.Identify != nil:
+			return pd2.String("IdentifyRequest"), x.s.Identify.Node(), nil
+			case x.s.GetP2PProvide != nil:
+			return pd2.String("GetP2PProvideRequest"), x.s.GetP2PProvide.Node(), nil
 
 		default:
 			return nil, nil, pd3.Errorf("no inductive cases are set")
@@ -68,28 +684,30 @@ func (x *AnonInductive0_MapIterator) Next() (key pd1.Node, value pd1.Node, err e
 	}
 }
 
-func (x *AnonInductive0_MapIterator) Done() bool {
+func (x *AnonInductive4_MapIterator) Done() bool {
 	return x.done
 }
 
-func (x AnonInductive0) Node() pd1.Node {
+func (x AnonInductive4) Node() pd1.Node {
 	return x
 }
 
-func (x AnonInductive0) Kind() pd1.Kind {
+func (x AnonInductive4) Kind() pd1.Kind {
 	return pd1.Kind_Map
 }
 
-func (x AnonInductive0) LookupByString(key string) (pd1.Node, error) {
+func (x AnonInductive4) LookupByString(key string) (pd1.Node, error) {
 	switch {
-	case x.GetP2PProvide != nil && key == "GetP2PProvide":
+		case x.Identify != nil && key == "IdentifyRequest":
+		return x.Identify.Node(), nil
+		case x.GetP2PProvide != nil && key == "GetP2PProvideRequest":
 		return x.GetP2PProvide.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive0) LookupByNode(key pd1.Node) (pd1.Node, error) {
+func (x AnonInductive4) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	if key.Kind() != pd1.Kind_String {
 		return nil, pd2.ErrNA
 	}
@@ -100,75 +718,79 @@ func (x AnonInductive0) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	}
 }
 
-func (x AnonInductive0) LookupByIndex(idx int64) (pd1.Node, error) {
+func (x AnonInductive4) LookupByIndex(idx int64) (pd1.Node, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive0) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+func (x AnonInductive4) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "GetP2PProvide":
+		case "IdentifyRequest":
+		return x.Identify.Node(), nil
+		case "GetP2PProvideRequest":
 		return x.GetP2PProvide.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive0) MapIterator() pd1.MapIterator {
-	return &AnonInductive0_MapIterator{false, &x}
+func (x AnonInductive4) MapIterator() pd1.MapIterator {
+	return &AnonInductive4_MapIterator{false, &x}
 }
 
-func (x AnonInductive0) ListIterator() pd1.ListIterator {
+func (x AnonInductive4) ListIterator() pd1.ListIterator {
 	return nil
 }
 
-func (x AnonInductive0) Length() int64 {
+func (x AnonInductive4) Length() int64 {
 	return 1
 }
 
-func (x AnonInductive0) IsAbsent() bool {
+func (x AnonInductive4) IsAbsent() bool {
 	return false
 }
 
-func (x AnonInductive0) IsNull() bool {
+func (x AnonInductive4) IsNull() bool {
 	return false
 }
 
-func (x AnonInductive0) AsBool() (bool, error) {
+func (x AnonInductive4) AsBool() (bool, error) {
 	return false, pd2.ErrNA
 }
 
-func (x AnonInductive0) AsInt() (int64, error) {
+func (x AnonInductive4) AsInt() (int64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x AnonInductive0) AsFloat() (float64, error) {
+func (x AnonInductive4) AsFloat() (float64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x AnonInductive0) AsString() (string, error) {
+func (x AnonInductive4) AsString() (string, error) {
 	return "", pd2.ErrNA
 }
 
-func (x AnonInductive0) AsBytes() ([]byte, error) {
+func (x AnonInductive4) AsBytes() ([]byte, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive0) AsLink() (pd1.Link, error) {
+func (x AnonInductive4) AsLink() (pd1.Link, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive0) Prototype() pd1.NodePrototype {
+func (x AnonInductive4) Prototype() pd1.NodePrototype {
 	return nil
 }
+// -- protocol type AnonInductive5 --
 
-// -- protocol type AnonInductive1 --
+type AnonInductive5 struct {
+		Identify *DelegatedRouting_IdentifyResult
+		GetP2PProvide *GetP2PProvideResponse
+		Error *DelegatedRouting_Error
 
-type AnonInductive1 struct {
-	GetP2PProvide *GetP2PProvideResponse
 }
 
-func (x *AnonInductive1) Parse(n pd1.Node) error {
-	*x = AnonInductive1{}
+func (x *AnonInductive5) Parse(n pd1.Node) error {
+	*x = AnonInductive5{}
 	if n.Kind() != pd1.Kind_Map {
 		return pd2.ErrNA
 	}
@@ -182,31 +804,49 @@ func (x *AnonInductive1) Parse(n pd1.Node) error {
 		return pd3.Errorf("inductive map key is not a string")
 	}
 	switch k {
-	case "GetP2PProvide":
+	case "IdentifyResponse":
+		var y DelegatedRouting_IdentifyResult
+		if err := y.Parse(vn); err != nil {
+			return err
+		}
+		x.Identify = &y
+		return nil
+	case "GetP2PProvideResponse":
 		var y GetP2PProvideResponse
 		if err := y.Parse(vn); err != nil {
 			return err
 		}
 		x.GetP2PProvide = &y
 		return nil
+	case "Error":
+		var y DelegatedRouting_Error
+		if err := y.Parse(vn); err != nil {
+			return err
+		}
+		x.Error = &y
+		return nil
 
 	}
 	return pd3.Errorf("inductive map has no applicable keys")
 }
 
-type AnonInductive1_MapIterator struct {
+type AnonInductive5_MapIterator struct {
 	done bool
-	s    *AnonInductive1
+	s    *AnonInductive5
 }
 
-func (x *AnonInductive1_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+func (x *AnonInductive5_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	if x.done {
 		return nil, nil, pd2.ErrNA
 	} else {
 		x.done = true
 		switch {
-		case x.s.GetP2PProvide != nil:
-			return pd2.String("GetP2PProvide"), x.s.GetP2PProvide.Node(), nil
+			case x.s.Identify != nil:
+			return pd2.String("IdentifyResponse"), x.s.Identify.Node(), nil
+			case x.s.GetP2PProvide != nil:
+			return pd2.String("GetP2PProvideResponse"), x.s.GetP2PProvide.Node(), nil
+			case x.s.Error != nil:
+			return pd2.String("Error"), x.s.Error.Node(), nil
 
 		default:
 			return nil, nil, pd3.Errorf("no inductive cases are set")
@@ -214,28 +854,32 @@ func (x *AnonInductive1_MapIterator) Next() (key pd1.Node, value pd1.Node, err e
 	}
 }
 
-func (x *AnonInductive1_MapIterator) Done() bool {
+func (x *AnonInductive5_MapIterator) Done() bool {
 	return x.done
 }
 
-func (x AnonInductive1) Node() pd1.Node {
+func (x AnonInductive5) Node() pd1.Node {
 	return x
 }
 
-func (x AnonInductive1) Kind() pd1.Kind {
+func (x AnonInductive5) Kind() pd1.Kind {
 	return pd1.Kind_Map
 }
 
-func (x AnonInductive1) LookupByString(key string) (pd1.Node, error) {
+func (x AnonInductive5) LookupByString(key string) (pd1.Node, error) {
 	switch {
-	case x.GetP2PProvide != nil && key == "GetP2PProvide":
+		case x.Identify != nil && key == "IdentifyResponse":
+		return x.Identify.Node(), nil
+		case x.GetP2PProvide != nil && key == "GetP2PProvideResponse":
 		return x.GetP2PProvide.Node(), nil
+		case x.Error != nil && key == "Error":
+		return x.Error.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive1) LookupByNode(key pd1.Node) (pd1.Node, error) {
+func (x AnonInductive5) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	if key.Kind() != pd1.Kind_String {
 		return nil, pd2.ErrNA
 	}
@@ -246,73 +890,89 @@ func (x AnonInductive1) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	}
 }
 
-func (x AnonInductive1) LookupByIndex(idx int64) (pd1.Node, error) {
+func (x AnonInductive5) LookupByIndex(idx int64) (pd1.Node, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive1) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+func (x AnonInductive5) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "GetP2PProvide":
+		case "IdentifyResponse":
+		return x.Identify.Node(), nil
+		case "GetP2PProvideResponse":
 		return x.GetP2PProvide.Node(), nil
+		case "Error":
+		return x.Error.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive1) MapIterator() pd1.MapIterator {
-	return &AnonInductive1_MapIterator{false, &x}
+func (x AnonInductive5) MapIterator() pd1.MapIterator {
+	return &AnonInductive5_MapIterator{false, &x}
 }
 
-func (x AnonInductive1) ListIterator() pd1.ListIterator {
+func (x AnonInductive5) ListIterator() pd1.ListIterator {
 	return nil
 }
 
-func (x AnonInductive1) Length() int64 {
+func (x AnonInductive5) Length() int64 {
 	return 1
 }
 
-func (x AnonInductive1) IsAbsent() bool {
+func (x AnonInductive5) IsAbsent() bool {
 	return false
 }
 
-func (x AnonInductive1) IsNull() bool {
+func (x AnonInductive5) IsNull() bool {
 	return false
 }
 
-func (x AnonInductive1) AsBool() (bool, error) {
+func (x AnonInductive5) AsBool() (bool, error) {
 	return false, pd2.ErrNA
 }
 
-func (x AnonInductive1) AsInt() (int64, error) {
+func (x AnonInductive5) AsInt() (int64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x AnonInductive1) AsFloat() (float64, error) {
+func (x AnonInductive5) AsFloat() (float64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x AnonInductive1) AsString() (string, error) {
+func (x AnonInductive5) AsString() (string, error) {
 	return "", pd2.ErrNA
 }
 
-func (x AnonInductive1) AsBytes() ([]byte, error) {
+func (x AnonInductive5) AsBytes() ([]byte, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive1) AsLink() (pd1.Link, error) {
+func (x AnonInductive5) AsLink() (pd1.Link, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x AnonInductive1) Prototype() pd1.NodePrototype {
+func (x AnonInductive5) Prototype() pd1.NodePrototype {
 	return nil
 }
-
-var logger_client_DelegatedRouting = pd12.Logger("service/client/DelegatedRouting")
+var logger_client_DelegatedRouting = pd13.Logger("service/client/DelegatedRouting")
 
 type DelegatedRouting_Client interface {
-	GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error)
 
-	GetP2PProvide_Async(ctx pd6.Context, req *GetP2PProvideRequest) (<-chan DelegatedRouting_GetP2PProvide_AsyncResult, error)
+Identify(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) ([]*DelegatedRouting_IdentifyResult, error)
+
+GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error)
+
+
+Identify_Async(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) (<-chan DelegatedRouting_Identify_AsyncResult, error)
+
+GetP2PProvide_Async(ctx pd6.Context, req *GetP2PProvideRequest) (<-chan DelegatedRouting_GetP2PProvide_AsyncResult, error)
+
+}
+
+
+type DelegatedRouting_Identify_AsyncResult struct {
+	Resp *DelegatedRouting_IdentifyResult
+	Err  error
 }
 
 type DelegatedRouting_GetP2PProvide_AsyncResult struct {
@@ -320,11 +980,12 @@ type DelegatedRouting_GetP2PProvide_AsyncResult struct {
 	Err  error
 }
 
+
 type DelegatedRouting_ClientOption func(*client_DelegatedRouting) error
 
 type client_DelegatedRouting struct {
-	httpClient *pd4.Client
-	endpoint   *pd11.URL
+	httpClient       *pd4.Client
+	endpoint     *pd9.URL
 }
 
 func DelegatedRouting_Client_WithHTTPClient(hc *pd4.Client) DelegatedRouting_ClientOption {
@@ -335,7 +996,7 @@ func DelegatedRouting_Client_WithHTTPClient(hc *pd4.Client) DelegatedRouting_Cli
 }
 
 func New_DelegatedRouting_Client(endpoint string, opts ...DelegatedRouting_ClientOption) (*client_DelegatedRouting, error) {
-	u, err := pd11.Parse(endpoint)
+	u, err := pd9.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -347,6 +1008,101 @@ func New_DelegatedRouting_Client(endpoint string, opts ...DelegatedRouting_Clien
 	}
 	return c, nil
 }
+
+
+
+func (c *client_DelegatedRouting) Identify(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) ([]*DelegatedRouting_IdentifyResult, error) {
+	ctx, cancel := pd6.WithCancel(ctx)
+	defer cancel()
+	ch, err := c.Identify_Async(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	var resps []*DelegatedRouting_IdentifyResult
+	for {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				cancel()
+				return resps, nil
+			} else {
+				if r.Err == nil {
+					resps = append(resps, r.Resp)
+				} else {
+					logger_client_DelegatedRouting.Errorf("client received erro response (%v)", r.Err)
+					cancel()
+					return resps, r.Err
+				}
+			}
+		case <-ctx.Done():
+			return resps, ctx.Err()
+		}
+	}
+}
+
+func (c *client_DelegatedRouting) Identify_Async(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) (<-chan DelegatedRouting_Identify_AsyncResult, error) {
+	envelope := &AnonInductive4{
+		Identify: req,
+	}
+
+	buf, err := pd8.Encode(envelope, pd10.Encode)
+	if err != nil {
+		return nil, pd3.Errorf("unexpected serialization error (%v)", err)
+	}
+
+	// encode request in URL
+	u := *c.endpoint
+	q := pd9.Values{}
+	q.Set("q", string(buf))
+	u.RawQuery = q.Encode()
+	httpReq, err := pd4.NewRequestWithContext(ctx, "POST", u.String(), pd11.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, pd3.Errorf("sending HTTP request (%v)", err)
+	}
+
+	ch := make(chan DelegatedRouting_Identify_AsyncResult, 1)
+	go process_DelegatedRouting_Identify_AsyncResult(ctx, ch, resp.Body)
+	return ch, nil
+}
+
+func process_DelegatedRouting_Identify_AsyncResult(ctx pd6.Context, ch chan<- DelegatedRouting_Identify_AsyncResult, r pd7.Reader) {
+	defer close(ch)
+	for {
+		if ctx.Err() != nil {
+			ch <- DelegatedRouting_Identify_AsyncResult{Err: pd12.ErrContext{Cause: ctx.Err()}} // context cancelled
+			return
+		}
+
+		n, err := pd8.DecodeStreaming(r, pd10.Decode)
+		if pd5.Is(err, pd7.EOF) || pd5.Is(err, pd7.ErrUnexpectedEOF) {
+			return
+		}
+		if err != nil {
+			ch <- DelegatedRouting_Identify_AsyncResult{Err: pd12.ErrProto{Cause: err}} // IPLD decode error
+			return
+		}
+		env := &AnonInductive5{}
+		if err = env.Parse(n); err != nil {
+			ch <- DelegatedRouting_Identify_AsyncResult{Err: pd12.ErrProto{Cause: err}} // schema decode error
+			return
+		}
+
+		if env.Error != nil {
+			ch <- DelegatedRouting_Identify_AsyncResult{Err: pd12.ErrService{Cause: pd5.New(string(env.Error.Code))}} // service-level error
+			return
+		}
+		if env.Identify == nil {
+			continue
+		}
+		ch <- DelegatedRouting_Identify_AsyncResult{Resp: env.Identify}
+	}
+}
+
 
 func (c *client_DelegatedRouting) GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error) {
 	ctx, cancel := pd6.WithCancel(ctx)
@@ -366,7 +1122,9 @@ func (c *client_DelegatedRouting) GetP2PProvide(ctx pd6.Context, req *GetP2PProv
 				if r.Err == nil {
 					resps = append(resps, r.Resp)
 				} else {
-					logger_client_DelegatedRouting.Errorf("client received invalid response (%v)", r.Err)
+					logger_client_DelegatedRouting.Errorf("client received erro response (%v)", r.Err)
+					cancel()
+					return resps, r.Err
 				}
 			}
 		case <-ctx.Done():
@@ -376,21 +1134,21 @@ func (c *client_DelegatedRouting) GetP2PProvide(ctx pd6.Context, req *GetP2PProv
 }
 
 func (c *client_DelegatedRouting) GetP2PProvide_Async(ctx pd6.Context, req *GetP2PProvideRequest) (<-chan DelegatedRouting_GetP2PProvide_AsyncResult, error) {
-	envelope := &AnonInductive0{
+	envelope := &AnonInductive4{
 		GetP2PProvide: req,
 	}
 
-	buf, err := pd5.Encode(envelope, pd7.Encode)
+	buf, err := pd8.Encode(envelope, pd10.Encode)
 	if err != nil {
 		return nil, pd3.Errorf("unexpected serialization error (%v)", err)
 	}
 
 	// encode request in URL
 	u := *c.endpoint
-	q := pd11.Values{}
+	q := pd9.Values{}
 	q.Set("q", string(buf))
 	u.RawQuery = q.Encode()
-	httpReq, err := pd4.NewRequestWithContext(ctx, "GET", u.String(), pd9.NewReader(buf))
+	httpReq, err := pd4.NewRequestWithContext(ctx, "POST", u.String(), pd11.NewReader(buf))
 	if err != nil {
 		return nil, err
 	}
@@ -405,27 +1163,32 @@ func (c *client_DelegatedRouting) GetP2PProvide_Async(ctx pd6.Context, req *GetP
 	return ch, nil
 }
 
-func process_DelegatedRouting_GetP2PProvide_AsyncResult(ctx pd6.Context, ch chan<- DelegatedRouting_GetP2PProvide_AsyncResult, r pd10.Reader) {
+func process_DelegatedRouting_GetP2PProvide_AsyncResult(ctx pd6.Context, ch chan<- DelegatedRouting_GetP2PProvide_AsyncResult, r pd7.Reader) {
 	defer close(ch)
 	for {
 		if ctx.Err() != nil {
+			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: pd12.ErrContext{Cause: ctx.Err()}} // context cancelled
 			return
 		}
 
-		n, err := pd5.DecodeStreaming(r, pd7.Decode)
-		if pd8.Is(err, pd10.EOF) || pd8.Is(err, pd10.ErrUnexpectedEOF) {
+		n, err := pd8.DecodeStreaming(r, pd10.Decode)
+		if pd5.Is(err, pd7.EOF) || pd5.Is(err, pd7.ErrUnexpectedEOF) {
 			return
 		}
 		if err != nil {
-			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: err}
+			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: pd12.ErrProto{Cause: err}} // IPLD decode error
 			return
 		}
-		env := &AnonInductive1{}
+		env := &AnonInductive5{}
 		if err = env.Parse(n); err != nil {
-			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: err}
+			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: pd12.ErrProto{Cause: err}} // schema decode error
 			return
 		}
 
+		if env.Error != nil {
+			ch <- DelegatedRouting_GetP2PProvide_AsyncResult{Err: pd12.ErrService{Cause: pd5.New(string(env.Error.Code))}} // service-level error
+			return
+		}
 		if env.GetP2PProvide == nil {
 			continue
 		}
@@ -433,23 +1196,25 @@ func process_DelegatedRouting_GetP2PProvide_AsyncResult(ctx pd6.Context, ch chan
 	}
 }
 
-var logger_server_DelegatedRouting = pd12.Logger("service/server/DelegatedRouting")
+
+var logger_server_DelegatedRouting = pd13.Logger("service/server/DelegatedRouting")
 
 type DelegatedRouting_Server interface {
-	GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest, respCh chan<- *GetP2PProvideResponse) error
+
+	GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest, respCh chan<- *DelegatedRouting_GetP2PProvide_AsyncResult) error
 }
 
 func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 	return func(writer pd4.ResponseWriter, request *pd4.Request) {
 		// parse request
 		msg := request.URL.Query().Get("q")
-		n, err := pd5.Decode([]byte(msg), pd7.Decode)
+		n, err := pd8.Decode([]byte(msg), pd10.Decode)
 		if err != nil {
 			logger_server_DelegatedRouting.Errorf("received request not decodeable (%v)", err)
 			writer.WriteHeader(400)
 			return
 		}
-		env := &AnonInductive0{}
+		env := &AnonInductive4{}
 		if err = env.Parse(n); err != nil {
 			logger_server_DelegatedRouting.Errorf("parsing call envelope (%v)", err)
 			writer.WriteHeader(400)
@@ -460,21 +1225,45 @@ func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 		switch {
 
 		case env.GetP2PProvide != nil:
-			ch := make(chan *GetP2PProvideResponse)
+			ch := make(chan *DelegatedRouting_GetP2PProvide_AsyncResult)
 			if err = s.GetP2PProvide(pd6.Background(), env.GetP2PProvide, ch); err != nil {
 				logger_server_DelegatedRouting.Errorf("get p2p provider rejected request (%v)", err)
 				writer.WriteHeader(500)
 				return
 			}
 			for resp := range ch {
-				env := &AnonInductive1{GetP2PProvide: resp}
-				buf, err := pd5.Encode(env, pd7.Encode)
+				var env *AnonInductive5
+				if resp.Err != nil {
+					env = &AnonInductive5{ Error: &DelegatedRouting_Error{Code: pd2.String(resp.Err.Error())} }
+				} else {
+					env = &AnonInductive5{ GetP2PProvide: resp.Resp }
+				}
+				buf, err := pd8.Encode(env, pd10.Encode)
 				if err != nil {
 					logger_server_DelegatedRouting.Errorf("cannot encode response (%v)", err)
 					continue
 				}
 				writer.Write(buf)
+		}
+
+
+		case env.Identify != nil:
+			var env *AnonInductive5
+			env = &AnonInductive5{
+				Identify: &DelegatedRouting_IdentifyResult{
+					Methods: []pd2.String{
+						"GetP2PProvide",
+
+					},
+				},
 			}
+			buf, err := pd8.Encode(env, pd10.Encode)
+			if err != nil {
+				logger_server_DelegatedRouting.Errorf("cannot encode identify response (%v)", err)
+				writer.WriteHeader(500)
+				return
+			}
+			writer.Write(buf)
 
 		default:
 			logger_server_DelegatedRouting.Errorf("missing or unknown request")
@@ -483,19 +1272,23 @@ func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 	}
 }
 
-// -- protocol type AnonList3 --
+// -- protocol type AnonList7 --
 
-type AnonList3 []Multihash
+type AnonList7 []Multihash
 
-func (v AnonList3) Node() pd1.Node {
+func (v AnonList7) Node() pd1.Node {
 	return v
 }
 
-func (v *AnonList3) Parse(n pd1.Node) error {
+func (v *AnonList7) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
 	if n.Kind() != pd1.Kind_List {
 		return pd2.ErrNA
 	} else {
-		*v = make(AnonList3, n.Length())
+		*v = make(AnonList7, n.Length())
 		iter := n.ListIterator()
 		for !iter.Done() {
 			if i, n, err := iter.Next(); err != nil {
@@ -508,19 +1301,19 @@ func (v *AnonList3) Parse(n pd1.Node) error {
 	}
 }
 
-func (AnonList3) Kind() pd1.Kind {
+func (AnonList7) Kind() pd1.Kind {
 	return pd1.Kind_List
 }
 
-func (AnonList3) LookupByString(string) (pd1.Node, error) {
+func (AnonList7) LookupByString(string) (pd1.Node, error) {
 	return nil, pd2.ErrNA
 }
 
-func (AnonList3) LookupByNode(key pd1.Node) (pd1.Node, error) {
+func (AnonList7) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	return nil, pd2.ErrNA
 }
 
-func (v AnonList3) LookupByIndex(i int64) (pd1.Node, error) {
+func (v AnonList7) LookupByIndex(i int64) (pd1.Node, error) {
 	if i < 0 || i >= v.Length() {
 		return nil, pd2.ErrBounds
 	} else {
@@ -528,7 +1321,7 @@ func (v AnonList3) LookupByIndex(i int64) (pd1.Node, error) {
 	}
 }
 
-func (v AnonList3) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+func (v AnonList7) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	if i, err := seg.Index(); err != nil {
 		return nil, pd2.ErrNA
 	} else {
@@ -536,60 +1329,60 @@ func (v AnonList3) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	}
 }
 
-func (AnonList3) MapIterator() pd1.MapIterator {
+func (AnonList7) MapIterator() pd1.MapIterator {
 	return nil
 }
 
-func (v AnonList3) ListIterator() pd1.ListIterator {
-	return &AnonList3_ListIterator{v, 0}
+func (v AnonList7) ListIterator() pd1.ListIterator {
+	return &AnonList7_ListIterator{v, 0}
 }
 
-func (v AnonList3) Length() int64 {
+func (v AnonList7) Length() int64 {
 	return int64(len(v))
 }
 
-func (AnonList3) IsAbsent() bool {
+func (AnonList7) IsAbsent() bool {
 	return false
 }
 
-func (AnonList3) IsNull() bool {
+func (AnonList7) IsNull() bool {
 	return false
 }
 
-func (v AnonList3) AsBool() (bool, error) {
+func (v AnonList7) AsBool() (bool, error) {
 	return false, pd2.ErrNA
 }
 
-func (AnonList3) AsInt() (int64, error) {
+func (AnonList7) AsInt() (int64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (AnonList3) AsFloat() (float64, error) {
+func (AnonList7) AsFloat() (float64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (AnonList3) AsString() (string, error) {
+func (AnonList7) AsString() (string, error) {
 	return "", pd2.ErrNA
 }
 
-func (AnonList3) AsBytes() ([]byte, error) {
+func (AnonList7) AsBytes() ([]byte, error) {
 	return nil, pd2.ErrNA
 }
 
-func (AnonList3) AsLink() (pd1.Link, error) {
+func (AnonList7) AsLink() (pd1.Link, error) {
 	return nil, pd2.ErrNA
 }
 
-func (AnonList3) Prototype() pd1.NodePrototype {
+func (AnonList7) Prototype() pd1.NodePrototype {
 	return nil // not needed
 }
 
-type AnonList3_ListIterator struct {
-	list AnonList3
+type AnonList7_ListIterator struct {
+	list AnonList7
 	at   int64
 }
 
-func (iter *AnonList3_ListIterator) Next() (int64, pd1.Node, error) {
+func (iter *AnonList7_ListIterator) Next() (int64, pd1.Node, error) {
 	if iter.Done() {
 		return -1, nil, pd2.ErrBounds
 	}
@@ -599,14 +1392,14 @@ func (iter *AnonList3_ListIterator) Next() (int64, pd1.Node, error) {
 	return i, v.Node(), nil
 }
 
-func (iter *AnonList3_ListIterator) Done() bool {
+func (iter *AnonList7_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
-
 // -- protocol type GetP2PProvideRequest --
 
 type GetP2PProvideRequest struct {
-	Keys AnonList3
+		Keys AnonList7
+
 }
 
 func (x GetP2PProvideRequest) Node() pd1.Node {
@@ -618,7 +1411,10 @@ func (x *GetP2PProvideRequest) Parse(n pd1.Node) error {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	nfields := 0
+	fieldMap := map[string]pd2.ParseFunc{
+				"Keys": x.Keys.Parse,
+
+	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -628,21 +1424,25 @@ func (x *GetP2PProvideRequest) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-				case "Keys":
-					if err := x.Keys.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
+			case "Keys":
+			if _, notParsed := fieldMap["Keys"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Keys")
+			}
+			if err := x.Keys.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Keys")
 
 				}
 			}
 		}
 	}
-	if nfields != 1 {
-		return pd2.ErrNA
-	} else {
-		return nil
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type GetP2PProvideRequest_MapIterator struct {
@@ -653,15 +1453,15 @@ type GetP2PProvideRequest_MapIterator struct {
 func (x *GetP2PProvideRequest_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-	case 0:
-		return pd2.String("Keys"), x.s.Keys.Node(), nil
+			case 0:
+			return pd2.String("Keys"), x.s.Keys.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *GetP2PProvideRequest_MapIterator) Done() bool {
-	return x.i+1 >= 1
+	return x.i + 1 >= 1
 }
 
 func (x GetP2PProvideRequest) Kind() pd1.Kind {
@@ -670,7 +1470,7 @@ func (x GetP2PProvideRequest) Kind() pd1.Kind {
 
 func (x GetP2PProvideRequest) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-	case "Keys":
+		case "Keys":
 		return x.Keys.Node(), nil
 
 	}
@@ -697,7 +1497,7 @@ func (x GetP2PProvideRequest) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x GetP2PProvideRequest) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-	case 0:
+		case 0:
 		return x.Keys.Node(), nil
 
 	}
@@ -706,7 +1506,7 @@ func (x GetP2PProvideRequest) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x GetP2PProvideRequest) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "0", "Keys":
+		case "0", "Keys":
 		return x.Keys.Node(), nil
 
 	}
@@ -761,623 +1561,19 @@ func (x GetP2PProvideRequest) Prototype() pd1.NodePrototype {
 	return nil
 }
 
-// -- protocol type AnonList5 --
-
-type AnonList5 []ProvidersByKey
-
-func (v AnonList5) Node() pd1.Node {
-	return v
-}
-
-func (v *AnonList5) Parse(n pd1.Node) error {
-	if n.Kind() != pd1.Kind_List {
-		return pd2.ErrNA
-	} else {
-		*v = make(AnonList5, n.Length())
-		iter := n.ListIterator()
-		for !iter.Done() {
-			if i, n, err := iter.Next(); err != nil {
-				return pd2.ErrNA
-			} else if err = (*v)[i].Parse(n); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-func (AnonList5) Kind() pd1.Kind {
-	return pd1.Kind_List
-}
-
-func (AnonList5) LookupByString(string) (pd1.Node, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList5) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	return nil, pd2.ErrNA
-}
-
-func (v AnonList5) LookupByIndex(i int64) (pd1.Node, error) {
-	if i < 0 || i >= v.Length() {
-		return nil, pd2.ErrBounds
-	} else {
-		return v[i].Node(), nil
-	}
-}
-
-func (v AnonList5) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	if i, err := seg.Index(); err != nil {
-		return nil, pd2.ErrNA
-	} else {
-		return v.LookupByIndex(i)
-	}
-}
-
-func (AnonList5) MapIterator() pd1.MapIterator {
-	return nil
-}
-
-func (v AnonList5) ListIterator() pd1.ListIterator {
-	return &AnonList5_ListIterator{v, 0}
-}
-
-func (v AnonList5) Length() int64 {
-	return int64(len(v))
-}
-
-func (AnonList5) IsAbsent() bool {
-	return false
-}
-
-func (AnonList5) IsNull() bool {
-	return false
-}
-
-func (v AnonList5) AsBool() (bool, error) {
-	return false, pd2.ErrNA
-}
-
-func (AnonList5) AsInt() (int64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (AnonList5) AsFloat() (float64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (AnonList5) AsString() (string, error) {
-	return "", pd2.ErrNA
-}
-
-func (AnonList5) AsBytes() ([]byte, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList5) AsLink() (pd1.Link, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList5) Prototype() pd1.NodePrototype {
-	return nil // not needed
-}
-
-type AnonList5_ListIterator struct {
-	list AnonList5
-	at   int64
-}
-
-func (iter *AnonList5_ListIterator) Next() (int64, pd1.Node, error) {
-	if iter.Done() {
-		return -1, nil, pd2.ErrBounds
-	}
-	v := iter.list[iter.at]
-	i := int64(iter.at)
-	iter.at++
-	return i, v.Node(), nil
-}
-
-func (iter *AnonList5_ListIterator) Done() bool {
-	return iter.at >= iter.list.Length()
-}
-
-// -- protocol type GetP2PProvideResponse --
-
-type GetP2PProvideResponse struct {
-	ProvidersByKey AnonList5
-}
-
-func (x GetP2PProvideResponse) Node() pd1.Node {
-	return x
-}
-
-func (x *GetP2PProvideResponse) Parse(n pd1.Node) error {
-	if n.Kind() != pd1.Kind_Map {
-		return pd2.ErrNA
-	}
-	iter := n.MapIterator()
-	nfields := 0
-	for !iter.Done() {
-		if kn, vn, err := iter.Next(); err != nil {
-			return err
-		} else {
-			if k, err := kn.AsString(); err != nil {
-				return pd3.Errorf("structure map key is not a string")
-			} else {
-				_ = vn
-				switch k {
-				case "ProvidersByKey":
-					if err := x.ProvidersByKey.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-
-				}
-			}
-		}
-	}
-	if nfields != 1 {
-		return pd2.ErrNA
-	} else {
-		return nil
-	}
-}
-
-type GetP2PProvideResponse_MapIterator struct {
-	i int64
-	s *GetP2PProvideResponse
-}
-
-func (x *GetP2PProvideResponse_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
-	x.i++
-	switch x.i {
-	case 0:
-		return pd2.String("ProvidersByKey"), x.s.ProvidersByKey.Node(), nil
-
-	}
-	return nil, nil, pd2.ErrNA
-}
-
-func (x *GetP2PProvideResponse_MapIterator) Done() bool {
-	return x.i+1 >= 1
-}
-
-func (x GetP2PProvideResponse) Kind() pd1.Kind {
-	return pd1.Kind_Map
-}
-
-func (x GetP2PProvideResponse) LookupByString(key string) (pd1.Node, error) {
-	switch key {
-	case "ProvidersByKey":
-		return x.ProvidersByKey.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	switch key.Kind() {
-	case pd1.Kind_String:
-		if s, err := key.AsString(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByString(s)
-		}
-	case pd1.Kind_Int:
-		if i, err := key.AsInt(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByIndex(i)
-		}
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) LookupByIndex(idx int64) (pd1.Node, error) {
-	switch idx {
-	case 0:
-		return x.ProvidersByKey.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	switch seg.String() {
-	case "0", "ProvidersByKey":
-		return x.ProvidersByKey.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) MapIterator() pd1.MapIterator {
-	return &GetP2PProvideResponse_MapIterator{-1, &x}
-}
-
-func (x GetP2PProvideResponse) ListIterator() pd1.ListIterator {
-	return nil
-}
-
-func (x GetP2PProvideResponse) Length() int64 {
-	return 1
-}
-
-func (x GetP2PProvideResponse) IsAbsent() bool {
-	return false
-}
-
-func (x GetP2PProvideResponse) IsNull() bool {
-	return false
-}
-
-func (x GetP2PProvideResponse) AsBool() (bool, error) {
-	return false, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) AsInt() (int64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) AsFloat() (float64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) AsString() (string, error) {
-	return "", pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) AsBytes() ([]byte, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) AsLink() (pd1.Link, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x GetP2PProvideResponse) Prototype() pd1.NodePrototype {
-	return nil
-}
-
-// -- protocol type ProvidersByKey --
-
-type ProvidersByKey struct {
-	Key      Multihash
-	Provider Provider
-}
-
-func (x ProvidersByKey) Node() pd1.Node {
-	return x
-}
-
-func (x *ProvidersByKey) Parse(n pd1.Node) error {
-	if n.Kind() != pd1.Kind_Map {
-		return pd2.ErrNA
-	}
-	iter := n.MapIterator()
-	nfields := 0
-	for !iter.Done() {
-		if kn, vn, err := iter.Next(); err != nil {
-			return err
-		} else {
-			if k, err := kn.AsString(); err != nil {
-				return pd3.Errorf("structure map key is not a string")
-			} else {
-				_ = vn
-				switch k {
-				case "Key":
-					if err := x.Key.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-				case "Provider":
-					if err := x.Provider.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-
-				}
-			}
-		}
-	}
-	if nfields != 2 {
-		return pd2.ErrNA
-	} else {
-		return nil
-	}
-}
-
-type ProvidersByKey_MapIterator struct {
-	i int64
-	s *ProvidersByKey
-}
-
-func (x *ProvidersByKey_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
-	x.i++
-	switch x.i {
-	case 0:
-		return pd2.String("Key"), x.s.Key.Node(), nil
-	case 1:
-		return pd2.String("Provider"), x.s.Provider.Node(), nil
-
-	}
-	return nil, nil, pd2.ErrNA
-}
-
-func (x *ProvidersByKey_MapIterator) Done() bool {
-	return x.i+1 >= 2
-}
-
-func (x ProvidersByKey) Kind() pd1.Kind {
-	return pd1.Kind_Map
-}
-
-func (x ProvidersByKey) LookupByString(key string) (pd1.Node, error) {
-	switch key {
-	case "Key":
-		return x.Key.Node(), nil
-	case "Provider":
-		return x.Provider.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	switch key.Kind() {
-	case pd1.Kind_String:
-		if s, err := key.AsString(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByString(s)
-		}
-	case pd1.Kind_Int:
-		if i, err := key.AsInt(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByIndex(i)
-		}
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) LookupByIndex(idx int64) (pd1.Node, error) {
-	switch idx {
-	case 0:
-		return x.Key.Node(), nil
-	case 1:
-		return x.Provider.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	switch seg.String() {
-	case "0", "Key":
-		return x.Key.Node(), nil
-	case "1", "Provider":
-		return x.Provider.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) MapIterator() pd1.MapIterator {
-	return &ProvidersByKey_MapIterator{-1, &x}
-}
-
-func (x ProvidersByKey) ListIterator() pd1.ListIterator {
-	return nil
-}
-
-func (x ProvidersByKey) Length() int64 {
-	return 2
-}
-
-func (x ProvidersByKey) IsAbsent() bool {
-	return false
-}
-
-func (x ProvidersByKey) IsNull() bool {
-	return false
-}
-
-func (x ProvidersByKey) AsBool() (bool, error) {
-	return false, pd2.ErrNA
-}
-
-func (x ProvidersByKey) AsInt() (int64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x ProvidersByKey) AsFloat() (float64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x ProvidersByKey) AsString() (string, error) {
-	return "", pd2.ErrNA
-}
-
-func (x ProvidersByKey) AsBytes() ([]byte, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) AsLink() (pd1.Link, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x ProvidersByKey) Prototype() pd1.NodePrototype {
-	return nil
-}
-
-// -- protocol type Multihash --
-
-type Multihash struct {
-	Bytes pd2.Bytes
-}
-
-func (x Multihash) Node() pd1.Node {
-	return x
-}
-
-func (x *Multihash) Parse(n pd1.Node) error {
-	if n.Kind() != pd1.Kind_Map {
-		return pd2.ErrNA
-	}
-	iter := n.MapIterator()
-	nfields := 0
-	for !iter.Done() {
-		if kn, vn, err := iter.Next(); err != nil {
-			return err
-		} else {
-			if k, err := kn.AsString(); err != nil {
-				return pd3.Errorf("structure map key is not a string")
-			} else {
-				_ = vn
-				switch k {
-				case "Bytes":
-					if err := x.Bytes.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-
-				}
-			}
-		}
-	}
-	if nfields != 1 {
-		return pd2.ErrNA
-	} else {
-		return nil
-	}
-}
-
-type Multihash_MapIterator struct {
-	i int64
-	s *Multihash
-}
-
-func (x *Multihash_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
-	x.i++
-	switch x.i {
-	case 0:
-		return pd2.String("Bytes"), x.s.Bytes.Node(), nil
-
-	}
-	return nil, nil, pd2.ErrNA
-}
-
-func (x *Multihash_MapIterator) Done() bool {
-	return x.i+1 >= 1
-}
-
-func (x Multihash) Kind() pd1.Kind {
-	return pd1.Kind_Map
-}
-
-func (x Multihash) LookupByString(key string) (pd1.Node, error) {
-	switch key {
-	case "Bytes":
-		return x.Bytes.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	switch key.Kind() {
-	case pd1.Kind_String:
-		if s, err := key.AsString(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByString(s)
-		}
-	case pd1.Kind_Int:
-		if i, err := key.AsInt(); err != nil {
-			return nil, err
-		} else {
-			return x.LookupByIndex(i)
-		}
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) LookupByIndex(idx int64) (pd1.Node, error) {
-	switch idx {
-	case 0:
-		return x.Bytes.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	switch seg.String() {
-	case "0", "Bytes":
-		return x.Bytes.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) MapIterator() pd1.MapIterator {
-	return &Multihash_MapIterator{-1, &x}
-}
-
-func (x Multihash) ListIterator() pd1.ListIterator {
-	return nil
-}
-
-func (x Multihash) Length() int64 {
-	return 1
-}
-
-func (x Multihash) IsAbsent() bool {
-	return false
-}
-
-func (x Multihash) IsNull() bool {
-	return false
-}
-
-func (x Multihash) AsBool() (bool, error) {
-	return false, pd2.ErrNA
-}
-
-func (x Multihash) AsInt() (int64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x Multihash) AsFloat() (float64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (x Multihash) AsString() (string, error) {
-	return "", pd2.ErrNA
-}
-
-func (x Multihash) AsBytes() ([]byte, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) AsLink() (pd1.Link, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x Multihash) Prototype() pd1.NodePrototype {
-	return nil
-}
-
 // -- protocol type AnonList9 --
 
-type AnonList9 []Node
+type AnonList9 []ProvidersByKey
 
 func (v AnonList9) Node() pd1.Node {
 	return v
 }
 
 func (v *AnonList9) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
 	if n.Kind() != pd1.Kind_List {
 		return pd2.ErrNA
 	} else {
@@ -1488,144 +1684,26 @@ func (iter *AnonList9_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList9_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+// -- protocol type GetP2PProvideResponse --
 
-// -- protocol type AnonList10 --
+type GetP2PProvideResponse struct {
+		ProvidersByKey AnonList9
 
-type AnonList10 []TransferProto
-
-func (v AnonList10) Node() pd1.Node {
-	return v
 }
 
-func (v *AnonList10) Parse(n pd1.Node) error {
-	if n.Kind() != pd1.Kind_List {
-		return pd2.ErrNA
-	} else {
-		*v = make(AnonList10, n.Length())
-		iter := n.ListIterator()
-		for !iter.Done() {
-			if i, n, err := iter.Next(); err != nil {
-				return pd2.ErrNA
-			} else if err = (*v)[i].Parse(n); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-func (AnonList10) Kind() pd1.Kind {
-	return pd1.Kind_List
-}
-
-func (AnonList10) LookupByString(string) (pd1.Node, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList10) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	return nil, pd2.ErrNA
-}
-
-func (v AnonList10) LookupByIndex(i int64) (pd1.Node, error) {
-	if i < 0 || i >= v.Length() {
-		return nil, pd2.ErrBounds
-	} else {
-		return v[i].Node(), nil
-	}
-}
-
-func (v AnonList10) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	if i, err := seg.Index(); err != nil {
-		return nil, pd2.ErrNA
-	} else {
-		return v.LookupByIndex(i)
-	}
-}
-
-func (AnonList10) MapIterator() pd1.MapIterator {
-	return nil
-}
-
-func (v AnonList10) ListIterator() pd1.ListIterator {
-	return &AnonList10_ListIterator{v, 0}
-}
-
-func (v AnonList10) Length() int64 {
-	return int64(len(v))
-}
-
-func (AnonList10) IsAbsent() bool {
-	return false
-}
-
-func (AnonList10) IsNull() bool {
-	return false
-}
-
-func (v AnonList10) AsBool() (bool, error) {
-	return false, pd2.ErrNA
-}
-
-func (AnonList10) AsInt() (int64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (AnonList10) AsFloat() (float64, error) {
-	return 0, pd2.ErrNA
-}
-
-func (AnonList10) AsString() (string, error) {
-	return "", pd2.ErrNA
-}
-
-func (AnonList10) AsBytes() ([]byte, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList10) AsLink() (pd1.Link, error) {
-	return nil, pd2.ErrNA
-}
-
-func (AnonList10) Prototype() pd1.NodePrototype {
-	return nil // not needed
-}
-
-type AnonList10_ListIterator struct {
-	list AnonList10
-	at   int64
-}
-
-func (iter *AnonList10_ListIterator) Next() (int64, pd1.Node, error) {
-	if iter.Done() {
-		return -1, nil, pd2.ErrBounds
-	}
-	v := iter.list[iter.at]
-	i := int64(iter.at)
-	iter.at++
-	return i, v.Node(), nil
-}
-
-func (iter *AnonList10_ListIterator) Done() bool {
-	return iter.at >= iter.list.Length()
-}
-
-// -- protocol type Provider --
-
-type Provider struct {
-	Nodes AnonList9
-	Proto AnonList10
-}
-
-func (x Provider) Node() pd1.Node {
+func (x GetP2PProvideResponse) Node() pd1.Node {
 	return x
 }
 
-func (x *Provider) Parse(n pd1.Node) error {
+func (x *GetP2PProvideResponse) Parse(n pd1.Node) error {
 	if n.Kind() != pd1.Kind_Map {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	nfields := 0
+	fieldMap := map[string]pd2.ParseFunc{
+				"ProvidersByKey": x.ProvidersByKey.Parse,
+
+	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -1635,65 +1713,60 @@ func (x *Provider) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-				case "Nodes":
-					if err := x.Nodes.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-				case "Proto":
-					if err := x.Proto.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
+			case "ProvidersByKey":
+			if _, notParsed := fieldMap["ProvidersByKey"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "ProvidersByKey")
+			}
+			if err := x.ProvidersByKey.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "ProvidersByKey")
 
 				}
 			}
 		}
 	}
-	if nfields != 2 {
-		return pd2.ErrNA
-	} else {
-		return nil
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-type Provider_MapIterator struct {
+type GetP2PProvideResponse_MapIterator struct {
 	i int64
-	s *Provider
+	s *GetP2PProvideResponse
 }
 
-func (x *Provider_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+func (x *GetP2PProvideResponse_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-	case 0:
-		return pd2.String("Nodes"), x.s.Nodes.Node(), nil
-	case 1:
-		return pd2.String("Proto"), x.s.Proto.Node(), nil
+			case 0:
+			return pd2.String("ProvidersByKey"), x.s.ProvidersByKey.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
-func (x *Provider_MapIterator) Done() bool {
-	return x.i+1 >= 2
+func (x *GetP2PProvideResponse_MapIterator) Done() bool {
+	return x.i + 1 >= 1
 }
 
-func (x Provider) Kind() pd1.Kind {
+func (x GetP2PProvideResponse) Kind() pd1.Kind {
 	return pd1.Kind_Map
 }
 
-func (x Provider) LookupByString(key string) (pd1.Node, error) {
+func (x GetP2PProvideResponse) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-	case "Nodes":
-		return x.Nodes.Node(), nil
-	case "Proto":
-		return x.Proto.Node(), nil
+		case "ProvidersByKey":
+		return x.ProvidersByKey.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) LookupByNode(key pd1.Node) (pd1.Node, error) {
+func (x GetP2PProvideResponse) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	switch key.Kind() {
 	case pd1.Kind_String:
 		if s, err := key.AsString(); err != nil {
@@ -1711,231 +1784,435 @@ func (x Provider) LookupByNode(key pd1.Node) (pd1.Node, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) LookupByIndex(idx int64) (pd1.Node, error) {
+func (x GetP2PProvideResponse) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-	case 0:
-		return x.Nodes.Node(), nil
-	case 1:
-		return x.Proto.Node(), nil
+		case 0:
+		return x.ProvidersByKey.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+func (x GetP2PProvideResponse) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "0", "Nodes":
-		return x.Nodes.Node(), nil
-	case "1", "Proto":
-		return x.Proto.Node(), nil
+		case "0", "ProvidersByKey":
+		return x.ProvidersByKey.Node(), nil
 
 	}
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) MapIterator() pd1.MapIterator {
-	return &Provider_MapIterator{-1, &x}
+func (x GetP2PProvideResponse) MapIterator() pd1.MapIterator {
+	return &GetP2PProvideResponse_MapIterator{-1, &x}
 }
 
-func (x Provider) ListIterator() pd1.ListIterator {
+func (x GetP2PProvideResponse) ListIterator() pd1.ListIterator {
 	return nil
 }
 
-func (x Provider) Length() int64 {
-	return 2
+func (x GetP2PProvideResponse) Length() int64 {
+	return 1
 }
 
-func (x Provider) IsAbsent() bool {
+func (x GetP2PProvideResponse) IsAbsent() bool {
 	return false
 }
 
-func (x Provider) IsNull() bool {
+func (x GetP2PProvideResponse) IsNull() bool {
 	return false
 }
 
-func (x Provider) AsBool() (bool, error) {
+func (x GetP2PProvideResponse) AsBool() (bool, error) {
 	return false, pd2.ErrNA
 }
 
-func (x Provider) AsInt() (int64, error) {
+func (x GetP2PProvideResponse) AsInt() (int64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x Provider) AsFloat() (float64, error) {
+func (x GetP2PProvideResponse) AsFloat() (float64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x Provider) AsString() (string, error) {
+func (x GetP2PProvideResponse) AsString() (string, error) {
 	return "", pd2.ErrNA
 }
 
-func (x Provider) AsBytes() ([]byte, error) {
+func (x GetP2PProvideResponse) AsBytes() ([]byte, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) AsLink() (pd1.Link, error) {
+func (x GetP2PProvideResponse) AsLink() (pd1.Link, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x Provider) Prototype() pd1.NodePrototype {
+func (x GetP2PProvideResponse) Prototype() pd1.NodePrototype {
 	return nil
 }
 
-// -- protocol type Node --
+// -- protocol type ProvidersByKey --
 
-type Node struct {
-	Peer *Peer
+type ProvidersByKey struct {
+		Key Multihash
+		Provider Provider
+
 }
 
-func (x *Node) Parse(n pd1.Node) error {
-	*x = Node{}
+func (x ProvidersByKey) Node() pd1.Node {
+	return x
+}
+
+func (x *ProvidersByKey) Parse(n pd1.Node) error {
 	if n.Kind() != pd1.Kind_Map {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	kn, vn, err := iter.Next()
-	if err != nil {
-		return err
+	fieldMap := map[string]pd2.ParseFunc{
+				"Key": x.Key.Parse,
+		"Provider": x.Provider.Parse,
+
 	}
-	k, err := kn.AsString()
-	if err != nil {
-		return pd3.Errorf("inductive map key is not a string")
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+			case "Key":
+			if _, notParsed := fieldMap["Key"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Key")
+			}
+			if err := x.Key.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Key")
+			case "Provider":
+			if _, notParsed := fieldMap["Provider"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Provider")
+			}
+			if err := x.Provider.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Provider")
+
+				}
+			}
+		}
 	}
-	switch k {
-	case "Peer":
-		var y Peer
-		if err := y.Parse(vn); err != nil {
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
 			return err
 		}
-		x.Peer = &y
-		return nil
-
 	}
-	return pd3.Errorf("inductive map has no applicable keys")
-}
-
-type Node_MapIterator struct {
-	done bool
-	s    *Node
-}
-
-func (x *Node_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
-	if x.done {
-		return nil, nil, pd2.ErrNA
-	} else {
-		x.done = true
-		switch {
-		case x.s.Peer != nil:
-			return pd2.String("Peer"), x.s.Peer.Node(), nil
-
-		default:
-			return nil, nil, pd3.Errorf("no inductive cases are set")
-		}
-	}
-}
-
-func (x *Node_MapIterator) Done() bool {
-	return x.done
-}
-
-func (x Node) Node() pd1.Node {
-	return x
-}
-
-func (x Node) Kind() pd1.Kind {
-	return pd1.Kind_Map
-}
-
-func (x Node) LookupByString(key string) (pd1.Node, error) {
-	switch {
-	case x.Peer != nil && key == "Peer":
-		return x.Peer.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Node) LookupByNode(key pd1.Node) (pd1.Node, error) {
-	if key.Kind() != pd1.Kind_String {
-		return nil, pd2.ErrNA
-	}
-	if s, err := key.AsString(); err != nil {
-		return nil, err
-	} else {
-		return x.LookupByString(s)
-	}
-}
-
-func (x Node) LookupByIndex(idx int64) (pd1.Node, error) {
-	return nil, pd2.ErrNA
-}
-
-func (x Node) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
-	switch seg.String() {
-	case "Peer":
-		return x.Peer.Node(), nil
-
-	}
-	return nil, pd2.ErrNA
-}
-
-func (x Node) MapIterator() pd1.MapIterator {
-	return &Node_MapIterator{false, &x}
-}
-
-func (x Node) ListIterator() pd1.ListIterator {
 	return nil
 }
 
-func (x Node) Length() int64 {
-	return 1
+type ProvidersByKey_MapIterator struct {
+	i int64
+	s *ProvidersByKey
 }
 
-func (x Node) IsAbsent() bool {
+func (x *ProvidersByKey_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+			case 0:
+			return pd2.String("Key"), x.s.Key.Node(), nil
+			case 1:
+			return pd2.String("Provider"), x.s.Provider.Node(), nil
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *ProvidersByKey_MapIterator) Done() bool {
+	return x.i + 1 >= 2
+}
+
+func (x ProvidersByKey) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x ProvidersByKey) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+		case "Key":
+		return x.Key.Node(), nil
+		case "Provider":
+		return x.Provider.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x ProvidersByKey) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x ProvidersByKey) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+		case 0:
+		return x.Key.Node(), nil
+		case 1:
+		return x.Provider.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x ProvidersByKey) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "0", "Key":
+		return x.Key.Node(), nil
+		case "1", "Provider":
+		return x.Provider.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x ProvidersByKey) MapIterator() pd1.MapIterator {
+	return &ProvidersByKey_MapIterator{-1, &x}
+}
+
+func (x ProvidersByKey) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x ProvidersByKey) Length() int64 {
+	return 2
+}
+
+func (x ProvidersByKey) IsAbsent() bool {
 	return false
 }
 
-func (x Node) IsNull() bool {
+func (x ProvidersByKey) IsNull() bool {
 	return false
 }
 
-func (x Node) AsBool() (bool, error) {
+func (x ProvidersByKey) AsBool() (bool, error) {
 	return false, pd2.ErrNA
 }
 
-func (x Node) AsInt() (int64, error) {
+func (x ProvidersByKey) AsInt() (int64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x Node) AsFloat() (float64, error) {
+func (x ProvidersByKey) AsFloat() (float64, error) {
 	return 0, pd2.ErrNA
 }
 
-func (x Node) AsString() (string, error) {
+func (x ProvidersByKey) AsString() (string, error) {
 	return "", pd2.ErrNA
 }
 
-func (x Node) AsBytes() ([]byte, error) {
+func (x ProvidersByKey) AsBytes() ([]byte, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x Node) AsLink() (pd1.Link, error) {
+func (x ProvidersByKey) AsLink() (pd1.Link, error) {
 	return nil, pd2.ErrNA
 }
 
-func (x Node) Prototype() pd1.NodePrototype {
+func (x ProvidersByKey) Prototype() pd1.NodePrototype {
+	return nil
+}
+
+// -- protocol type Multihash --
+
+type Multihash struct {
+		Bytes pd2.Bytes
+
+}
+
+func (x Multihash) Node() pd1.Node {
+	return x
+}
+
+func (x *Multihash) Parse(n pd1.Node) error {
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	fieldMap := map[string]pd2.ParseFunc{
+				"Bytes": x.Bytes.Parse,
+
+	}
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+			case "Bytes":
+			if _, notParsed := fieldMap["Bytes"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Bytes")
+			}
+			if err := x.Bytes.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Bytes")
+
+				}
+			}
+		}
+	}
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type Multihash_MapIterator struct {
+	i int64
+	s *Multihash
+}
+
+func (x *Multihash_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+			case 0:
+			return pd2.String("Bytes"), x.s.Bytes.Node(), nil
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *Multihash_MapIterator) Done() bool {
+	return x.i + 1 >= 1
+}
+
+func (x Multihash) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x Multihash) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+		case "Bytes":
+		return x.Bytes.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+		case 0:
+		return x.Bytes.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "0", "Bytes":
+		return x.Bytes.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) MapIterator() pd1.MapIterator {
+	return &Multihash_MapIterator{-1, &x}
+}
+
+func (x Multihash) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x Multihash) Length() int64 {
+	return 1
+}
+
+func (x Multihash) IsAbsent() bool {
+	return false
+}
+
+func (x Multihash) IsNull() bool {
+	return false
+}
+
+func (x Multihash) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x Multihash) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Multihash) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Multihash) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x Multihash) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Multihash) Prototype() pd1.NodePrototype {
 	return nil
 }
 
 // -- protocol type AnonList13 --
 
-type AnonList13 []pd2.Bytes
+type AnonList13 []Node
 
 func (v AnonList13) Node() pd1.Node {
 	return v
 }
 
 func (v *AnonList13) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
 	if n.Kind() != pd1.Kind_List {
 		return pd2.ErrNA
 	} else {
@@ -2046,12 +2323,588 @@ func (iter *AnonList13_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList13_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+// -- protocol type AnonList14 --
 
+type AnonList14 []TransferProto
+
+func (v AnonList14) Node() pd1.Node {
+	return v
+}
+
+func (v *AnonList14) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
+	if n.Kind() != pd1.Kind_List {
+		return pd2.ErrNA
+	} else {
+		*v = make(AnonList14, n.Length())
+		iter := n.ListIterator()
+		for !iter.Done() {
+			if i, n, err := iter.Next(); err != nil {
+				return pd2.ErrNA
+			} else if err = (*v)[i].Parse(n); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (AnonList14) Kind() pd1.Kind {
+	return pd1.Kind_List
+}
+
+func (AnonList14) LookupByString(string) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList14) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (v AnonList14) LookupByIndex(i int64) (pd1.Node, error) {
+	if i < 0 || i >= v.Length() {
+		return nil, pd2.ErrBounds
+	} else {
+		return v[i].Node(), nil
+	}
+}
+
+func (v AnonList14) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	if i, err := seg.Index(); err != nil {
+		return nil, pd2.ErrNA
+	} else {
+		return v.LookupByIndex(i)
+	}
+}
+
+func (AnonList14) MapIterator() pd1.MapIterator {
+	return nil
+}
+
+func (v AnonList14) ListIterator() pd1.ListIterator {
+	return &AnonList14_ListIterator{v, 0}
+}
+
+func (v AnonList14) Length() int64 {
+	return int64(len(v))
+}
+
+func (AnonList14) IsAbsent() bool {
+	return false
+}
+
+func (AnonList14) IsNull() bool {
+	return false
+}
+
+func (v AnonList14) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (AnonList14) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList14) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList14) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (AnonList14) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList14) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList14) Prototype() pd1.NodePrototype {
+	return nil // not needed
+}
+
+type AnonList14_ListIterator struct {
+	list AnonList14
+	at   int64
+}
+
+func (iter *AnonList14_ListIterator) Next() (int64, pd1.Node, error) {
+	if iter.Done() {
+		return -1, nil, pd2.ErrBounds
+	}
+	v := iter.list[iter.at]
+	i := int64(iter.at)
+	iter.at++
+	return i, v.Node(), nil
+}
+
+func (iter *AnonList14_ListIterator) Done() bool {
+	return iter.at >= iter.list.Length()
+}
+// -- protocol type Provider --
+
+type Provider struct {
+		Nodes AnonList13
+		Proto AnonList14
+
+}
+
+func (x Provider) Node() pd1.Node {
+	return x
+}
+
+func (x *Provider) Parse(n pd1.Node) error {
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	fieldMap := map[string]pd2.ParseFunc{
+				"Nodes": x.Nodes.Parse,
+		"Proto": x.Proto.Parse,
+
+	}
+	for !iter.Done() {
+		if kn, vn, err := iter.Next(); err != nil {
+			return err
+		} else {
+			if k, err := kn.AsString(); err != nil {
+				return pd3.Errorf("structure map key is not a string")
+			} else {
+				_ = vn
+				switch k {
+			case "Nodes":
+			if _, notParsed := fieldMap["Nodes"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Nodes")
+			}
+			if err := x.Nodes.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Nodes")
+			case "Proto":
+			if _, notParsed := fieldMap["Proto"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Proto")
+			}
+			if err := x.Proto.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Proto")
+
+				}
+			}
+		}
+	}
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type Provider_MapIterator struct {
+	i int64
+	s *Provider
+}
+
+func (x *Provider_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	x.i++
+	switch x.i {
+			case 0:
+			return pd2.String("Nodes"), x.s.Nodes.Node(), nil
+			case 1:
+			return pd2.String("Proto"), x.s.Proto.Node(), nil
+
+	}
+	return nil, nil, pd2.ErrNA
+}
+
+func (x *Provider_MapIterator) Done() bool {
+	return x.i + 1 >= 2
+}
+
+func (x Provider) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x Provider) LookupByString(key string) (pd1.Node, error) {
+	switch key {
+		case "Nodes":
+		return x.Nodes.Node(), nil
+		case "Proto":
+		return x.Proto.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	switch key.Kind() {
+	case pd1.Kind_String:
+		if s, err := key.AsString(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByString(s)
+		}
+	case pd1.Kind_Int:
+		if i, err := key.AsInt(); err != nil {
+			return nil, err
+		} else {
+			return x.LookupByIndex(i)
+		}
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) LookupByIndex(idx int64) (pd1.Node, error) {
+	switch idx {
+		case 0:
+		return x.Nodes.Node(), nil
+		case 1:
+		return x.Proto.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "0", "Nodes":
+		return x.Nodes.Node(), nil
+		case "1", "Proto":
+		return x.Proto.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) MapIterator() pd1.MapIterator {
+	return &Provider_MapIterator{-1, &x}
+}
+
+func (x Provider) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x Provider) Length() int64 {
+	return 2
+}
+
+func (x Provider) IsAbsent() bool {
+	return false
+}
+
+func (x Provider) IsNull() bool {
+	return false
+}
+
+func (x Provider) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x Provider) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Provider) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Provider) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x Provider) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Provider) Prototype() pd1.NodePrototype {
+	return nil
+}
+
+// -- protocol type Node --
+
+type Node struct {
+		Peer *Peer
+
+}
+
+func (x *Node) Parse(n pd1.Node) error {
+	*x = Node{}
+	if n.Kind() != pd1.Kind_Map {
+		return pd2.ErrNA
+	}
+	iter := n.MapIterator()
+	kn, vn, err := iter.Next()
+	if err != nil {
+		return err
+	}
+	k, err := kn.AsString()
+	if err != nil {
+		return pd3.Errorf("inductive map key is not a string")
+	}
+	switch k {
+	case "Peer":
+		var y Peer
+		if err := y.Parse(vn); err != nil {
+			return err
+		}
+		x.Peer = &y
+		return nil
+
+	}
+	return pd3.Errorf("inductive map has no applicable keys")
+}
+
+type Node_MapIterator struct {
+	done bool
+	s    *Node
+}
+
+func (x *Node_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
+	if x.done {
+		return nil, nil, pd2.ErrNA
+	} else {
+		x.done = true
+		switch {
+			case x.s.Peer != nil:
+			return pd2.String("Peer"), x.s.Peer.Node(), nil
+
+		default:
+			return nil, nil, pd3.Errorf("no inductive cases are set")
+		}
+	}
+}
+
+func (x *Node_MapIterator) Done() bool {
+	return x.done
+}
+
+func (x Node) Node() pd1.Node {
+	return x
+}
+
+func (x Node) Kind() pd1.Kind {
+	return pd1.Kind_Map
+}
+
+func (x Node) LookupByString(key string) (pd1.Node, error) {
+	switch {
+		case x.Peer != nil && key == "Peer":
+		return x.Peer.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Node) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	if key.Kind() != pd1.Kind_String {
+		return nil, pd2.ErrNA
+	}
+	if s, err := key.AsString(); err != nil {
+		return nil, err
+	} else {
+		return x.LookupByString(s)
+	}
+}
+
+func (x Node) LookupByIndex(idx int64) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Node) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	switch seg.String() {
+		case "Peer":
+		return x.Peer.Node(), nil
+
+	}
+	return nil, pd2.ErrNA
+}
+
+func (x Node) MapIterator() pd1.MapIterator {
+	return &Node_MapIterator{false, &x}
+}
+
+func (x Node) ListIterator() pd1.ListIterator {
+	return nil
+}
+
+func (x Node) Length() int64 {
+	return 1
+}
+
+func (x Node) IsAbsent() bool {
+	return false
+}
+
+func (x Node) IsNull() bool {
+	return false
+}
+
+func (x Node) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (x Node) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Node) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (x Node) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (x Node) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Node) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (x Node) Prototype() pd1.NodePrototype {
+	return nil
+}
+// -- protocol type AnonList17 --
+
+type AnonList17 []pd2.Bytes
+
+func (v AnonList17) Node() pd1.Node {
+	return v
+}
+
+func (v *AnonList17) Parse(n pd1.Node) error {
+	if n.Kind() == pd1.Kind_Null {
+		*v = nil
+		return nil
+	}
+	if n.Kind() != pd1.Kind_List {
+		return pd2.ErrNA
+	} else {
+		*v = make(AnonList17, n.Length())
+		iter := n.ListIterator()
+		for !iter.Done() {
+			if i, n, err := iter.Next(); err != nil {
+				return pd2.ErrNA
+			} else if err = (*v)[i].Parse(n); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (AnonList17) Kind() pd1.Kind {
+	return pd1.Kind_List
+}
+
+func (AnonList17) LookupByString(string) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList17) LookupByNode(key pd1.Node) (pd1.Node, error) {
+	return nil, pd2.ErrNA
+}
+
+func (v AnonList17) LookupByIndex(i int64) (pd1.Node, error) {
+	if i < 0 || i >= v.Length() {
+		return nil, pd2.ErrBounds
+	} else {
+		return v[i].Node(), nil
+	}
+}
+
+func (v AnonList17) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
+	if i, err := seg.Index(); err != nil {
+		return nil, pd2.ErrNA
+	} else {
+		return v.LookupByIndex(i)
+	}
+}
+
+func (AnonList17) MapIterator() pd1.MapIterator {
+	return nil
+}
+
+func (v AnonList17) ListIterator() pd1.ListIterator {
+	return &AnonList17_ListIterator{v, 0}
+}
+
+func (v AnonList17) Length() int64 {
+	return int64(len(v))
+}
+
+func (AnonList17) IsAbsent() bool {
+	return false
+}
+
+func (AnonList17) IsNull() bool {
+	return false
+}
+
+func (v AnonList17) AsBool() (bool, error) {
+	return false, pd2.ErrNA
+}
+
+func (AnonList17) AsInt() (int64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList17) AsFloat() (float64, error) {
+	return 0, pd2.ErrNA
+}
+
+func (AnonList17) AsString() (string, error) {
+	return "", pd2.ErrNA
+}
+
+func (AnonList17) AsBytes() ([]byte, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList17) AsLink() (pd1.Link, error) {
+	return nil, pd2.ErrNA
+}
+
+func (AnonList17) Prototype() pd1.NodePrototype {
+	return nil // not needed
+}
+
+type AnonList17_ListIterator struct {
+	list AnonList17
+	at   int64
+}
+
+func (iter *AnonList17_ListIterator) Next() (int64, pd1.Node, error) {
+	if iter.Done() {
+		return -1, nil, pd2.ErrBounds
+	}
+	v := iter.list[iter.at]
+	i := int64(iter.at)
+	iter.at++
+	return i, v.Node(), nil
+}
+
+func (iter *AnonList17_ListIterator) Done() bool {
+	return iter.at >= iter.list.Length()
+}
 // -- protocol type Peer --
 
 type Peer struct {
-	ID             pd2.Bytes
-	Multiaddresses AnonList13
+		ID pd2.Bytes
+		Multiaddresses AnonList17
+
 }
 
 func (x Peer) Node() pd1.Node {
@@ -2063,7 +2916,11 @@ func (x *Peer) Parse(n pd1.Node) error {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	nfields := 0
+	fieldMap := map[string]pd2.ParseFunc{
+				"ID": x.ID.Parse,
+		"Multiaddresses": x.Multiaddresses.Parse,
+
+	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -2073,26 +2930,33 @@ func (x *Peer) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-				case "ID":
-					if err := x.ID.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
-				case "Multiaddresses":
-					if err := x.Multiaddresses.Parse(vn); err != nil {
-						return err
-					}
-					nfields++
+			case "ID":
+			if _, notParsed := fieldMap["ID"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "ID")
+			}
+			if err := x.ID.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "ID")
+			case "Multiaddresses":
+			if _, notParsed := fieldMap["Multiaddresses"]; !notParsed {
+				return pd3.Errorf("field %s already parsed", "Multiaddresses")
+			}
+			if err := x.Multiaddresses.Parse(vn); err != nil {
+				return err
+			}
+			delete(fieldMap, "Multiaddresses")
 
 				}
 			}
 		}
 	}
-	if nfields != 2 {
-		return pd2.ErrNA
-	} else {
-		return nil
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type Peer_MapIterator struct {
@@ -2103,17 +2967,17 @@ type Peer_MapIterator struct {
 func (x *Peer_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-	case 0:
-		return pd2.String("ID"), x.s.ID.Node(), nil
-	case 1:
-		return pd2.String("Multiaddresses"), x.s.Multiaddresses.Node(), nil
+			case 0:
+			return pd2.String("ID"), x.s.ID.Node(), nil
+			case 1:
+			return pd2.String("Multiaddresses"), x.s.Multiaddresses.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *Peer_MapIterator) Done() bool {
-	return x.i+1 >= 2
+	return x.i + 1 >= 2
 }
 
 func (x Peer) Kind() pd1.Kind {
@@ -2122,9 +2986,9 @@ func (x Peer) Kind() pd1.Kind {
 
 func (x Peer) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-	case "ID":
+		case "ID":
 		return x.ID.Node(), nil
-	case "Multiaddresses":
+		case "Multiaddresses":
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -2151,9 +3015,9 @@ func (x Peer) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x Peer) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-	case 0:
+		case 0:
 		return x.ID.Node(), nil
-	case 1:
+		case 1:
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -2162,9 +3026,9 @@ func (x Peer) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x Peer) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "0", "ID":
+		case "0", "ID":
 		return x.ID.Node(), nil
-	case "1", "Multiaddresses":
+		case "1", "Multiaddresses":
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -2222,7 +3086,8 @@ func (x Peer) Prototype() pd1.NodePrototype {
 // -- protocol type TransferProto --
 
 type TransferProto struct {
-	Bitswap *BitswapTransfer
+		Bitswap *BitswapTransfer
+
 }
 
 func (x *TransferProto) Parse(n pd1.Node) error {
@@ -2263,7 +3128,7 @@ func (x *TransferProto_MapIterator) Next() (key pd1.Node, value pd1.Node, err er
 	} else {
 		x.done = true
 		switch {
-		case x.s.Bitswap != nil:
+			case x.s.Bitswap != nil:
 			return pd2.String("Bitswap"), x.s.Bitswap.Node(), nil
 
 		default:
@@ -2286,7 +3151,7 @@ func (x TransferProto) Kind() pd1.Kind {
 
 func (x TransferProto) LookupByString(key string) (pd1.Node, error) {
 	switch {
-	case x.Bitswap != nil && key == "Bitswap":
+		case x.Bitswap != nil && key == "Bitswap":
 		return x.Bitswap.Node(), nil
 
 	}
@@ -2310,7 +3175,7 @@ func (x TransferProto) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x TransferProto) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-	case "Bitswap":
+		case "Bitswap":
 		return x.Bitswap.Node(), nil
 
 	}
@@ -2364,10 +3229,10 @@ func (x TransferProto) AsLink() (pd1.Link, error) {
 func (x TransferProto) Prototype() pd1.NodePrototype {
 	return nil
 }
-
 // -- protocol type BitswapTransfer --
 
 type BitswapTransfer struct {
+
 }
 
 func (x BitswapTransfer) Node() pd1.Node {
@@ -2379,7 +3244,9 @@ func (x *BitswapTransfer) Parse(n pd1.Node) error {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	nfields := 0
+	fieldMap := map[string]pd2.ParseFunc{
+		
+	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -2394,11 +3261,12 @@ func (x *BitswapTransfer) Parse(n pd1.Node) error {
 			}
 		}
 	}
-	if nfields != 0 {
-		return pd2.ErrNA
-	} else {
-		return nil
+	for _, fieldParse := range fieldMap {
+		if err := fieldParse(pd1.Null); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type BitswapTransfer_MapIterator struct {
@@ -2415,7 +3283,7 @@ func (x *BitswapTransfer_MapIterator) Next() (key pd1.Node, value pd1.Node, err 
 }
 
 func (x *BitswapTransfer_MapIterator) Done() bool {
-	return x.i+1 >= 0
+	return x.i + 1 >= 0
 }
 
 func (x BitswapTransfer) Kind() pd1.Kind {

--- a/examples/gen-routing-api/proto/proto_edelweiss.go
+++ b/examples/gen-routing-api/proto/proto_edelweiss.go
@@ -1,26 +1,25 @@
 package proto
 
-import(
-	pd1 "github.com/ipld/go-ipld-prime/datamodel"
-	pd2 "github.com/ipld/edelweiss/values"
-	pd3 "fmt"
-	pd4 "net/http"
-	pd5 "errors"
-	pd6 "context"
-	pd7 "io"
-	pd8 "github.com/ipld/go-ipld-prime"
-	pd9 "net/url"
-	pd10 "github.com/ipld/go-ipld-prime/codec/dagjson"
+import (
 	pd11 "bytes"
-	pd12 "github.com/ipld/edelweiss/services"
-	pd13 "github.com/ipfs/go-log"
-)
+	pd6 "context"
+	pd5 "errors"
+	pd3 "fmt"
+	pd7 "io"
+	pd4 "net/http"
+	pd9 "net/url"
 
+	pd13 "github.com/ipfs/go-log"
+	pd12 "github.com/ipld/edelweiss/services"
+	pd2 "github.com/ipld/edelweiss/values"
+	pd8 "github.com/ipld/go-ipld-prime"
+	pd10 "github.com/ipld/go-ipld-prime/codec/dagjson"
+	pd1 "github.com/ipld/go-ipld-prime/datamodel"
+)
 
 // -- protocol type DelegatedRouting_IdentifyArg --
 
 type DelegatedRouting_IdentifyArg struct {
-
 }
 
 func (x DelegatedRouting_IdentifyArg) Node() pd1.Node {
@@ -32,9 +31,7 @@ func (x *DelegatedRouting_IdentifyArg) Parse(n pd1.Node) error {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	fieldMap := map[string]pd2.ParseFunc{
-		
-	}
+	fieldMap := map[string]pd2.ParseFunc{}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -71,7 +68,7 @@ func (x *DelegatedRouting_IdentifyArg_MapIterator) Next() (key pd1.Node, value p
 }
 
 func (x *DelegatedRouting_IdentifyArg_MapIterator) Done() bool {
-	return x.i + 1 >= 0
+	return x.i+1 >= 0
 }
 
 func (x DelegatedRouting_IdentifyArg) Kind() pd1.Kind {
@@ -288,11 +285,11 @@ func (iter *AnonList1_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList1_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type DelegatedRouting_IdentifyResult --
 
 type DelegatedRouting_IdentifyResult struct {
-		Methods AnonList1
-
+	Methods AnonList1
 }
 
 func (x DelegatedRouting_IdentifyResult) Node() pd1.Node {
@@ -305,8 +302,7 @@ func (x *DelegatedRouting_IdentifyResult) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Methods": x.Methods.Parse,
-
+		"Methods": x.Methods.Parse,
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -317,14 +313,14 @@ func (x *DelegatedRouting_IdentifyResult) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Methods":
-			if _, notParsed := fieldMap["Methods"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Methods")
-			}
-			if err := x.Methods.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Methods")
+				case "Methods":
+					if _, notParsed := fieldMap["Methods"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Methods")
+					}
+					if err := x.Methods.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Methods")
 
 				}
 			}
@@ -346,15 +342,15 @@ type DelegatedRouting_IdentifyResult_MapIterator struct {
 func (x *DelegatedRouting_IdentifyResult_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Methods"), x.s.Methods.Node(), nil
+	case 0:
+		return pd2.String("Methods"), x.s.Methods.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *DelegatedRouting_IdentifyResult_MapIterator) Done() bool {
-	return x.i + 1 >= 1
+	return x.i+1 >= 1
 }
 
 func (x DelegatedRouting_IdentifyResult) Kind() pd1.Kind {
@@ -363,7 +359,7 @@ func (x DelegatedRouting_IdentifyResult) Kind() pd1.Kind {
 
 func (x DelegatedRouting_IdentifyResult) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Methods":
+	case "Methods":
 		return x.Methods.Node(), nil
 
 	}
@@ -390,7 +386,7 @@ func (x DelegatedRouting_IdentifyResult) LookupByNode(key pd1.Node) (pd1.Node, e
 
 func (x DelegatedRouting_IdentifyResult) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Methods.Node(), nil
 
 	}
@@ -399,7 +395,7 @@ func (x DelegatedRouting_IdentifyResult) LookupByIndex(idx int64) (pd1.Node, err
 
 func (x DelegatedRouting_IdentifyResult) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Methods":
+	case "0", "Methods":
 		return x.Methods.Node(), nil
 
 	}
@@ -457,8 +453,7 @@ func (x DelegatedRouting_IdentifyResult) Prototype() pd1.NodePrototype {
 // -- protocol type DelegatedRouting_Error --
 
 type DelegatedRouting_Error struct {
-		Code pd2.String
-
+	Code pd2.String
 }
 
 func (x DelegatedRouting_Error) Node() pd1.Node {
@@ -471,8 +466,7 @@ func (x *DelegatedRouting_Error) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Code": x.Code.Parse,
-
+		"Code": x.Code.Parse,
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -483,14 +477,14 @@ func (x *DelegatedRouting_Error) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Code":
-			if _, notParsed := fieldMap["Code"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Code")
-			}
-			if err := x.Code.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Code")
+				case "Code":
+					if _, notParsed := fieldMap["Code"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Code")
+					}
+					if err := x.Code.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Code")
 
 				}
 			}
@@ -512,15 +506,15 @@ type DelegatedRouting_Error_MapIterator struct {
 func (x *DelegatedRouting_Error_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Code"), x.s.Code.Node(), nil
+	case 0:
+		return pd2.String("Code"), x.s.Code.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *DelegatedRouting_Error_MapIterator) Done() bool {
-	return x.i + 1 >= 1
+	return x.i+1 >= 1
 }
 
 func (x DelegatedRouting_Error) Kind() pd1.Kind {
@@ -529,7 +523,7 @@ func (x DelegatedRouting_Error) Kind() pd1.Kind {
 
 func (x DelegatedRouting_Error) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Code":
+	case "Code":
 		return x.Code.Node(), nil
 
 	}
@@ -556,7 +550,7 @@ func (x DelegatedRouting_Error) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x DelegatedRouting_Error) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Code.Node(), nil
 
 	}
@@ -565,7 +559,7 @@ func (x DelegatedRouting_Error) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x DelegatedRouting_Error) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Code":
+	case "0", "Code":
 		return x.Code.Node(), nil
 
 	}
@@ -623,9 +617,8 @@ func (x DelegatedRouting_Error) Prototype() pd1.NodePrototype {
 // -- protocol type AnonInductive4 --
 
 type AnonInductive4 struct {
-		Identify *DelegatedRouting_IdentifyArg
-		GetP2PProvide *GetP2PProvideRequest
-
+	Identify      *DelegatedRouting_IdentifyArg
+	GetP2PProvide *GetP2PProvideRequest
 }
 
 func (x *AnonInductive4) Parse(n pd1.Node) error {
@@ -673,9 +666,9 @@ func (x *AnonInductive4_MapIterator) Next() (key pd1.Node, value pd1.Node, err e
 	} else {
 		x.done = true
 		switch {
-			case x.s.Identify != nil:
+		case x.s.Identify != nil:
 			return pd2.String("IdentifyRequest"), x.s.Identify.Node(), nil
-			case x.s.GetP2PProvide != nil:
+		case x.s.GetP2PProvide != nil:
 			return pd2.String("GetP2PProvideRequest"), x.s.GetP2PProvide.Node(), nil
 
 		default:
@@ -698,9 +691,9 @@ func (x AnonInductive4) Kind() pd1.Kind {
 
 func (x AnonInductive4) LookupByString(key string) (pd1.Node, error) {
 	switch {
-		case x.Identify != nil && key == "IdentifyRequest":
+	case x.Identify != nil && key == "IdentifyRequest":
 		return x.Identify.Node(), nil
-		case x.GetP2PProvide != nil && key == "GetP2PProvideRequest":
+	case x.GetP2PProvide != nil && key == "GetP2PProvideRequest":
 		return x.GetP2PProvide.Node(), nil
 
 	}
@@ -724,9 +717,9 @@ func (x AnonInductive4) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x AnonInductive4) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "IdentifyRequest":
+	case "IdentifyRequest":
 		return x.Identify.Node(), nil
-		case "GetP2PProvideRequest":
+	case "GetP2PProvideRequest":
 		return x.GetP2PProvide.Node(), nil
 
 	}
@@ -780,13 +773,13 @@ func (x AnonInductive4) AsLink() (pd1.Link, error) {
 func (x AnonInductive4) Prototype() pd1.NodePrototype {
 	return nil
 }
+
 // -- protocol type AnonInductive5 --
 
 type AnonInductive5 struct {
-		Identify *DelegatedRouting_IdentifyResult
-		GetP2PProvide *GetP2PProvideResponse
-		Error *DelegatedRouting_Error
-
+	Identify      *DelegatedRouting_IdentifyResult
+	GetP2PProvide *GetP2PProvideResponse
+	Error         *DelegatedRouting_Error
 }
 
 func (x *AnonInductive5) Parse(n pd1.Node) error {
@@ -841,11 +834,11 @@ func (x *AnonInductive5_MapIterator) Next() (key pd1.Node, value pd1.Node, err e
 	} else {
 		x.done = true
 		switch {
-			case x.s.Identify != nil:
+		case x.s.Identify != nil:
 			return pd2.String("IdentifyResponse"), x.s.Identify.Node(), nil
-			case x.s.GetP2PProvide != nil:
+		case x.s.GetP2PProvide != nil:
 			return pd2.String("GetP2PProvideResponse"), x.s.GetP2PProvide.Node(), nil
-			case x.s.Error != nil:
+		case x.s.Error != nil:
 			return pd2.String("Error"), x.s.Error.Node(), nil
 
 		default:
@@ -868,11 +861,11 @@ func (x AnonInductive5) Kind() pd1.Kind {
 
 func (x AnonInductive5) LookupByString(key string) (pd1.Node, error) {
 	switch {
-		case x.Identify != nil && key == "IdentifyResponse":
+	case x.Identify != nil && key == "IdentifyResponse":
 		return x.Identify.Node(), nil
-		case x.GetP2PProvide != nil && key == "GetP2PProvideResponse":
+	case x.GetP2PProvide != nil && key == "GetP2PProvideResponse":
 		return x.GetP2PProvide.Node(), nil
-		case x.Error != nil && key == "Error":
+	case x.Error != nil && key == "Error":
 		return x.Error.Node(), nil
 
 	}
@@ -896,11 +889,11 @@ func (x AnonInductive5) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x AnonInductive5) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "IdentifyResponse":
+	case "IdentifyResponse":
 		return x.Identify.Node(), nil
-		case "GetP2PProvideResponse":
+	case "GetP2PProvideResponse":
 		return x.GetP2PProvide.Node(), nil
-		case "Error":
+	case "Error":
 		return x.Error.Node(), nil
 
 	}
@@ -954,21 +947,18 @@ func (x AnonInductive5) AsLink() (pd1.Link, error) {
 func (x AnonInductive5) Prototype() pd1.NodePrototype {
 	return nil
 }
+
 var logger_client_DelegatedRouting = pd13.Logger("service/client/DelegatedRouting")
 
 type DelegatedRouting_Client interface {
+	Identify(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) ([]*DelegatedRouting_IdentifyResult, error)
 
-Identify(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) ([]*DelegatedRouting_IdentifyResult, error)
+	GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error)
 
-GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error)
+	Identify_Async(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) (<-chan DelegatedRouting_Identify_AsyncResult, error)
 
-
-Identify_Async(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) (<-chan DelegatedRouting_Identify_AsyncResult, error)
-
-GetP2PProvide_Async(ctx pd6.Context, req *GetP2PProvideRequest) (<-chan DelegatedRouting_GetP2PProvide_AsyncResult, error)
-
+	GetP2PProvide_Async(ctx pd6.Context, req *GetP2PProvideRequest) (<-chan DelegatedRouting_GetP2PProvide_AsyncResult, error)
 }
-
 
 type DelegatedRouting_Identify_AsyncResult struct {
 	Resp *DelegatedRouting_IdentifyResult
@@ -980,12 +970,11 @@ type DelegatedRouting_GetP2PProvide_AsyncResult struct {
 	Err  error
 }
 
-
 type DelegatedRouting_ClientOption func(*client_DelegatedRouting) error
 
 type client_DelegatedRouting struct {
-	httpClient       *pd4.Client
-	endpoint     *pd9.URL
+	httpClient *pd4.Client
+	endpoint   *pd9.URL
 }
 
 func DelegatedRouting_Client_WithHTTPClient(hc *pd4.Client) DelegatedRouting_ClientOption {
@@ -1008,8 +997,6 @@ func New_DelegatedRouting_Client(endpoint string, opts ...DelegatedRouting_Clien
 	}
 	return c, nil
 }
-
-
 
 func (c *client_DelegatedRouting) Identify(ctx pd6.Context, req *DelegatedRouting_IdentifyArg) ([]*DelegatedRouting_IdentifyResult, error) {
 	ctx, cancel := pd6.WithCancel(ctx)
@@ -1103,7 +1090,6 @@ func process_DelegatedRouting_Identify_AsyncResult(ctx pd6.Context, ch chan<- De
 	}
 }
 
-
 func (c *client_DelegatedRouting) GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest) ([]*GetP2PProvideResponse, error) {
 	ctx, cancel := pd6.WithCancel(ctx)
 	defer cancel()
@@ -1196,11 +1182,9 @@ func process_DelegatedRouting_GetP2PProvide_AsyncResult(ctx pd6.Context, ch chan
 	}
 }
 
-
 var logger_server_DelegatedRouting = pd13.Logger("service/server/DelegatedRouting")
 
 type DelegatedRouting_Server interface {
-
 	GetP2PProvide(ctx pd6.Context, req *GetP2PProvideRequest, respCh chan<- *DelegatedRouting_GetP2PProvide_AsyncResult) error
 }
 
@@ -1234,9 +1218,9 @@ func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 			for resp := range ch {
 				var env *AnonInductive5
 				if resp.Err != nil {
-					env = &AnonInductive5{ Error: &DelegatedRouting_Error{Code: pd2.String(resp.Err.Error())} }
+					env = &AnonInductive5{Error: &DelegatedRouting_Error{Code: pd2.String(resp.Err.Error())}}
 				} else {
-					env = &AnonInductive5{ GetP2PProvide: resp.Resp }
+					env = &AnonInductive5{GetP2PProvide: resp.Resp}
 				}
 				buf, err := pd8.Encode(env, pd10.Encode)
 				if err != nil {
@@ -1244,8 +1228,7 @@ func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 					continue
 				}
 				writer.Write(buf)
-		}
-
+			}
 
 		case env.Identify != nil:
 			var env *AnonInductive5
@@ -1253,7 +1236,6 @@ func DelegatedRouting_AsyncHandler(s DelegatedRouting_Server) pd4.HandlerFunc {
 				Identify: &DelegatedRouting_IdentifyResult{
 					Methods: []pd2.String{
 						"GetP2PProvide",
-
 					},
 				},
 			}
@@ -1395,11 +1377,11 @@ func (iter *AnonList7_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList7_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type GetP2PProvideRequest --
 
 type GetP2PProvideRequest struct {
-		Keys AnonList7
-
+	Keys AnonList7
 }
 
 func (x GetP2PProvideRequest) Node() pd1.Node {
@@ -1412,8 +1394,7 @@ func (x *GetP2PProvideRequest) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Keys": x.Keys.Parse,
-
+		"Keys": x.Keys.Parse,
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -1424,14 +1405,14 @@ func (x *GetP2PProvideRequest) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Keys":
-			if _, notParsed := fieldMap["Keys"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Keys")
-			}
-			if err := x.Keys.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Keys")
+				case "Keys":
+					if _, notParsed := fieldMap["Keys"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Keys")
+					}
+					if err := x.Keys.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Keys")
 
 				}
 			}
@@ -1453,15 +1434,15 @@ type GetP2PProvideRequest_MapIterator struct {
 func (x *GetP2PProvideRequest_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Keys"), x.s.Keys.Node(), nil
+	case 0:
+		return pd2.String("Keys"), x.s.Keys.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *GetP2PProvideRequest_MapIterator) Done() bool {
-	return x.i + 1 >= 1
+	return x.i+1 >= 1
 }
 
 func (x GetP2PProvideRequest) Kind() pd1.Kind {
@@ -1470,7 +1451,7 @@ func (x GetP2PProvideRequest) Kind() pd1.Kind {
 
 func (x GetP2PProvideRequest) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Keys":
+	case "Keys":
 		return x.Keys.Node(), nil
 
 	}
@@ -1497,7 +1478,7 @@ func (x GetP2PProvideRequest) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x GetP2PProvideRequest) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Keys.Node(), nil
 
 	}
@@ -1506,7 +1487,7 @@ func (x GetP2PProvideRequest) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x GetP2PProvideRequest) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Keys":
+	case "0", "Keys":
 		return x.Keys.Node(), nil
 
 	}
@@ -1684,11 +1665,11 @@ func (iter *AnonList9_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList9_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type GetP2PProvideResponse --
 
 type GetP2PProvideResponse struct {
-		ProvidersByKey AnonList9
-
+	ProvidersByKey AnonList9
 }
 
 func (x GetP2PProvideResponse) Node() pd1.Node {
@@ -1701,8 +1682,7 @@ func (x *GetP2PProvideResponse) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"ProvidersByKey": x.ProvidersByKey.Parse,
-
+		"ProvidersByKey": x.ProvidersByKey.Parse,
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -1713,14 +1693,14 @@ func (x *GetP2PProvideResponse) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "ProvidersByKey":
-			if _, notParsed := fieldMap["ProvidersByKey"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "ProvidersByKey")
-			}
-			if err := x.ProvidersByKey.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "ProvidersByKey")
+				case "ProvidersByKey":
+					if _, notParsed := fieldMap["ProvidersByKey"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "ProvidersByKey")
+					}
+					if err := x.ProvidersByKey.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "ProvidersByKey")
 
 				}
 			}
@@ -1742,15 +1722,15 @@ type GetP2PProvideResponse_MapIterator struct {
 func (x *GetP2PProvideResponse_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("ProvidersByKey"), x.s.ProvidersByKey.Node(), nil
+	case 0:
+		return pd2.String("ProvidersByKey"), x.s.ProvidersByKey.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *GetP2PProvideResponse_MapIterator) Done() bool {
-	return x.i + 1 >= 1
+	return x.i+1 >= 1
 }
 
 func (x GetP2PProvideResponse) Kind() pd1.Kind {
@@ -1759,7 +1739,7 @@ func (x GetP2PProvideResponse) Kind() pd1.Kind {
 
 func (x GetP2PProvideResponse) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "ProvidersByKey":
+	case "ProvidersByKey":
 		return x.ProvidersByKey.Node(), nil
 
 	}
@@ -1786,7 +1766,7 @@ func (x GetP2PProvideResponse) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x GetP2PProvideResponse) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.ProvidersByKey.Node(), nil
 
 	}
@@ -1795,7 +1775,7 @@ func (x GetP2PProvideResponse) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x GetP2PProvideResponse) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "ProvidersByKey":
+	case "0", "ProvidersByKey":
 		return x.ProvidersByKey.Node(), nil
 
 	}
@@ -1853,9 +1833,8 @@ func (x GetP2PProvideResponse) Prototype() pd1.NodePrototype {
 // -- protocol type ProvidersByKey --
 
 type ProvidersByKey struct {
-		Key Multihash
-		Provider Provider
-
+	Key      Multihash
+	Provider Provider
 }
 
 func (x ProvidersByKey) Node() pd1.Node {
@@ -1868,9 +1847,8 @@ func (x *ProvidersByKey) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Key": x.Key.Parse,
+		"Key":      x.Key.Parse,
 		"Provider": x.Provider.Parse,
-
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -1881,22 +1859,22 @@ func (x *ProvidersByKey) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Key":
-			if _, notParsed := fieldMap["Key"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Key")
-			}
-			if err := x.Key.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Key")
-			case "Provider":
-			if _, notParsed := fieldMap["Provider"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Provider")
-			}
-			if err := x.Provider.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Provider")
+				case "Key":
+					if _, notParsed := fieldMap["Key"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Key")
+					}
+					if err := x.Key.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Key")
+				case "Provider":
+					if _, notParsed := fieldMap["Provider"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Provider")
+					}
+					if err := x.Provider.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Provider")
 
 				}
 			}
@@ -1918,17 +1896,17 @@ type ProvidersByKey_MapIterator struct {
 func (x *ProvidersByKey_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Key"), x.s.Key.Node(), nil
-			case 1:
-			return pd2.String("Provider"), x.s.Provider.Node(), nil
+	case 0:
+		return pd2.String("Key"), x.s.Key.Node(), nil
+	case 1:
+		return pd2.String("Provider"), x.s.Provider.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *ProvidersByKey_MapIterator) Done() bool {
-	return x.i + 1 >= 2
+	return x.i+1 >= 2
 }
 
 func (x ProvidersByKey) Kind() pd1.Kind {
@@ -1937,9 +1915,9 @@ func (x ProvidersByKey) Kind() pd1.Kind {
 
 func (x ProvidersByKey) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Key":
+	case "Key":
 		return x.Key.Node(), nil
-		case "Provider":
+	case "Provider":
 		return x.Provider.Node(), nil
 
 	}
@@ -1966,9 +1944,9 @@ func (x ProvidersByKey) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x ProvidersByKey) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Key.Node(), nil
-		case 1:
+	case 1:
 		return x.Provider.Node(), nil
 
 	}
@@ -1977,9 +1955,9 @@ func (x ProvidersByKey) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x ProvidersByKey) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Key":
+	case "0", "Key":
 		return x.Key.Node(), nil
-		case "1", "Provider":
+	case "1", "Provider":
 		return x.Provider.Node(), nil
 
 	}
@@ -2037,8 +2015,7 @@ func (x ProvidersByKey) Prototype() pd1.NodePrototype {
 // -- protocol type Multihash --
 
 type Multihash struct {
-		Bytes pd2.Bytes
-
+	Bytes pd2.Bytes
 }
 
 func (x Multihash) Node() pd1.Node {
@@ -2051,8 +2028,7 @@ func (x *Multihash) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Bytes": x.Bytes.Parse,
-
+		"Bytes": x.Bytes.Parse,
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -2063,14 +2039,14 @@ func (x *Multihash) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Bytes":
-			if _, notParsed := fieldMap["Bytes"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Bytes")
-			}
-			if err := x.Bytes.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Bytes")
+				case "Bytes":
+					if _, notParsed := fieldMap["Bytes"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Bytes")
+					}
+					if err := x.Bytes.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Bytes")
 
 				}
 			}
@@ -2092,15 +2068,15 @@ type Multihash_MapIterator struct {
 func (x *Multihash_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Bytes"), x.s.Bytes.Node(), nil
+	case 0:
+		return pd2.String("Bytes"), x.s.Bytes.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *Multihash_MapIterator) Done() bool {
-	return x.i + 1 >= 1
+	return x.i+1 >= 1
 }
 
 func (x Multihash) Kind() pd1.Kind {
@@ -2109,7 +2085,7 @@ func (x Multihash) Kind() pd1.Kind {
 
 func (x Multihash) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Bytes":
+	case "Bytes":
 		return x.Bytes.Node(), nil
 
 	}
@@ -2136,7 +2112,7 @@ func (x Multihash) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x Multihash) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Bytes.Node(), nil
 
 	}
@@ -2145,7 +2121,7 @@ func (x Multihash) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x Multihash) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Bytes":
+	case "0", "Bytes":
 		return x.Bytes.Node(), nil
 
 	}
@@ -2323,6 +2299,7 @@ func (iter *AnonList13_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList13_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type AnonList14 --
 
 type AnonList14 []TransferProto
@@ -2446,12 +2423,12 @@ func (iter *AnonList14_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList14_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type Provider --
 
 type Provider struct {
-		Nodes AnonList13
-		Proto AnonList14
-
+	Nodes AnonList13
+	Proto AnonList14
 }
 
 func (x Provider) Node() pd1.Node {
@@ -2464,9 +2441,8 @@ func (x *Provider) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"Nodes": x.Nodes.Parse,
+		"Nodes": x.Nodes.Parse,
 		"Proto": x.Proto.Parse,
-
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -2477,22 +2453,22 @@ func (x *Provider) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "Nodes":
-			if _, notParsed := fieldMap["Nodes"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Nodes")
-			}
-			if err := x.Nodes.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Nodes")
-			case "Proto":
-			if _, notParsed := fieldMap["Proto"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Proto")
-			}
-			if err := x.Proto.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Proto")
+				case "Nodes":
+					if _, notParsed := fieldMap["Nodes"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Nodes")
+					}
+					if err := x.Nodes.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Nodes")
+				case "Proto":
+					if _, notParsed := fieldMap["Proto"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Proto")
+					}
+					if err := x.Proto.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Proto")
 
 				}
 			}
@@ -2514,17 +2490,17 @@ type Provider_MapIterator struct {
 func (x *Provider_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("Nodes"), x.s.Nodes.Node(), nil
-			case 1:
-			return pd2.String("Proto"), x.s.Proto.Node(), nil
+	case 0:
+		return pd2.String("Nodes"), x.s.Nodes.Node(), nil
+	case 1:
+		return pd2.String("Proto"), x.s.Proto.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *Provider_MapIterator) Done() bool {
-	return x.i + 1 >= 2
+	return x.i+1 >= 2
 }
 
 func (x Provider) Kind() pd1.Kind {
@@ -2533,9 +2509,9 @@ func (x Provider) Kind() pd1.Kind {
 
 func (x Provider) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "Nodes":
+	case "Nodes":
 		return x.Nodes.Node(), nil
-		case "Proto":
+	case "Proto":
 		return x.Proto.Node(), nil
 
 	}
@@ -2562,9 +2538,9 @@ func (x Provider) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x Provider) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.Nodes.Node(), nil
-		case 1:
+	case 1:
 		return x.Proto.Node(), nil
 
 	}
@@ -2573,9 +2549,9 @@ func (x Provider) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x Provider) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "Nodes":
+	case "0", "Nodes":
 		return x.Nodes.Node(), nil
-		case "1", "Proto":
+	case "1", "Proto":
 		return x.Proto.Node(), nil
 
 	}
@@ -2633,8 +2609,7 @@ func (x Provider) Prototype() pd1.NodePrototype {
 // -- protocol type Node --
 
 type Node struct {
-		Peer *Peer
-
+	Peer *Peer
 }
 
 func (x *Node) Parse(n pd1.Node) error {
@@ -2675,7 +2650,7 @@ func (x *Node_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	} else {
 		x.done = true
 		switch {
-			case x.s.Peer != nil:
+		case x.s.Peer != nil:
 			return pd2.String("Peer"), x.s.Peer.Node(), nil
 
 		default:
@@ -2698,7 +2673,7 @@ func (x Node) Kind() pd1.Kind {
 
 func (x Node) LookupByString(key string) (pd1.Node, error) {
 	switch {
-		case x.Peer != nil && key == "Peer":
+	case x.Peer != nil && key == "Peer":
 		return x.Peer.Node(), nil
 
 	}
@@ -2722,7 +2697,7 @@ func (x Node) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x Node) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "Peer":
+	case "Peer":
 		return x.Peer.Node(), nil
 
 	}
@@ -2776,6 +2751,7 @@ func (x Node) AsLink() (pd1.Link, error) {
 func (x Node) Prototype() pd1.NodePrototype {
 	return nil
 }
+
 // -- protocol type AnonList17 --
 
 type AnonList17 []pd2.Bytes
@@ -2899,12 +2875,12 @@ func (iter *AnonList17_ListIterator) Next() (int64, pd1.Node, error) {
 func (iter *AnonList17_ListIterator) Done() bool {
 	return iter.at >= iter.list.Length()
 }
+
 // -- protocol type Peer --
 
 type Peer struct {
-		ID pd2.Bytes
-		Multiaddresses AnonList17
-
+	ID             pd2.Bytes
+	Multiaddresses AnonList17
 }
 
 func (x Peer) Node() pd1.Node {
@@ -2917,9 +2893,8 @@ func (x *Peer) Parse(n pd1.Node) error {
 	}
 	iter := n.MapIterator()
 	fieldMap := map[string]pd2.ParseFunc{
-				"ID": x.ID.Parse,
+		"ID":             x.ID.Parse,
 		"Multiaddresses": x.Multiaddresses.Parse,
-
 	}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
@@ -2930,22 +2905,22 @@ func (x *Peer) Parse(n pd1.Node) error {
 			} else {
 				_ = vn
 				switch k {
-			case "ID":
-			if _, notParsed := fieldMap["ID"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "ID")
-			}
-			if err := x.ID.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "ID")
-			case "Multiaddresses":
-			if _, notParsed := fieldMap["Multiaddresses"]; !notParsed {
-				return pd3.Errorf("field %s already parsed", "Multiaddresses")
-			}
-			if err := x.Multiaddresses.Parse(vn); err != nil {
-				return err
-			}
-			delete(fieldMap, "Multiaddresses")
+				case "ID":
+					if _, notParsed := fieldMap["ID"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "ID")
+					}
+					if err := x.ID.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "ID")
+				case "Multiaddresses":
+					if _, notParsed := fieldMap["Multiaddresses"]; !notParsed {
+						return pd3.Errorf("field %s already parsed", "Multiaddresses")
+					}
+					if err := x.Multiaddresses.Parse(vn); err != nil {
+						return err
+					}
+					delete(fieldMap, "Multiaddresses")
 
 				}
 			}
@@ -2967,17 +2942,17 @@ type Peer_MapIterator struct {
 func (x *Peer_MapIterator) Next() (key pd1.Node, value pd1.Node, err error) {
 	x.i++
 	switch x.i {
-			case 0:
-			return pd2.String("ID"), x.s.ID.Node(), nil
-			case 1:
-			return pd2.String("Multiaddresses"), x.s.Multiaddresses.Node(), nil
+	case 0:
+		return pd2.String("ID"), x.s.ID.Node(), nil
+	case 1:
+		return pd2.String("Multiaddresses"), x.s.Multiaddresses.Node(), nil
 
 	}
 	return nil, nil, pd2.ErrNA
 }
 
 func (x *Peer_MapIterator) Done() bool {
-	return x.i + 1 >= 2
+	return x.i+1 >= 2
 }
 
 func (x Peer) Kind() pd1.Kind {
@@ -2986,9 +2961,9 @@ func (x Peer) Kind() pd1.Kind {
 
 func (x Peer) LookupByString(key string) (pd1.Node, error) {
 	switch key {
-		case "ID":
+	case "ID":
 		return x.ID.Node(), nil
-		case "Multiaddresses":
+	case "Multiaddresses":
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -3015,9 +2990,9 @@ func (x Peer) LookupByNode(key pd1.Node) (pd1.Node, error) {
 
 func (x Peer) LookupByIndex(idx int64) (pd1.Node, error) {
 	switch idx {
-		case 0:
+	case 0:
 		return x.ID.Node(), nil
-		case 1:
+	case 1:
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -3026,9 +3001,9 @@ func (x Peer) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x Peer) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "0", "ID":
+	case "0", "ID":
 		return x.ID.Node(), nil
-		case "1", "Multiaddresses":
+	case "1", "Multiaddresses":
 		return x.Multiaddresses.Node(), nil
 
 	}
@@ -3086,8 +3061,7 @@ func (x Peer) Prototype() pd1.NodePrototype {
 // -- protocol type TransferProto --
 
 type TransferProto struct {
-		Bitswap *BitswapTransfer
-
+	Bitswap *BitswapTransfer
 }
 
 func (x *TransferProto) Parse(n pd1.Node) error {
@@ -3128,7 +3102,7 @@ func (x *TransferProto_MapIterator) Next() (key pd1.Node, value pd1.Node, err er
 	} else {
 		x.done = true
 		switch {
-			case x.s.Bitswap != nil:
+		case x.s.Bitswap != nil:
 			return pd2.String("Bitswap"), x.s.Bitswap.Node(), nil
 
 		default:
@@ -3151,7 +3125,7 @@ func (x TransferProto) Kind() pd1.Kind {
 
 func (x TransferProto) LookupByString(key string) (pd1.Node, error) {
 	switch {
-		case x.Bitswap != nil && key == "Bitswap":
+	case x.Bitswap != nil && key == "Bitswap":
 		return x.Bitswap.Node(), nil
 
 	}
@@ -3175,7 +3149,7 @@ func (x TransferProto) LookupByIndex(idx int64) (pd1.Node, error) {
 
 func (x TransferProto) LookupBySegment(seg pd1.PathSegment) (pd1.Node, error) {
 	switch seg.String() {
-		case "Bitswap":
+	case "Bitswap":
 		return x.Bitswap.Node(), nil
 
 	}
@@ -3229,10 +3203,10 @@ func (x TransferProto) AsLink() (pd1.Link, error) {
 func (x TransferProto) Prototype() pd1.NodePrototype {
 	return nil
 }
+
 // -- protocol type BitswapTransfer --
 
 type BitswapTransfer struct {
-
 }
 
 func (x BitswapTransfer) Node() pd1.Node {
@@ -3244,9 +3218,7 @@ func (x *BitswapTransfer) Parse(n pd1.Node) error {
 		return pd2.ErrNA
 	}
 	iter := n.MapIterator()
-	fieldMap := map[string]pd2.ParseFunc{
-		
-	}
+	fieldMap := map[string]pd2.ParseFunc{}
 	for !iter.Done() {
 		if kn, vn, err := iter.Next(); err != nil {
 			return err
@@ -3283,7 +3255,7 @@ func (x *BitswapTransfer_MapIterator) Next() (key pd1.Node, value pd1.Node, err 
 }
 
 func (x *BitswapTransfer_MapIterator) Done() bool {
-	return x.i + 1 >= 0
+	return x.i+1 >= 0
 }
 
 func (x BitswapTransfer) Kind() pd1.Kind {

--- a/plans/service.go
+++ b/plans/service.go
@@ -2,6 +2,7 @@ package plans
 
 type Service struct {
 	Methods        Methods
+	ErrorEnvelope  BuiltinOrRefPlan
 	CallEnvelope   BuiltinOrRefPlan
 	ReturnEnvelope BuiltinOrRefPlan
 }

--- a/plans/service.go
+++ b/plans/service.go
@@ -5,7 +5,10 @@ type Service struct {
 	ErrorEnvelope  BuiltinOrRefPlan
 	CallEnvelope   BuiltinOrRefPlan
 	ReturnEnvelope BuiltinOrRefPlan
+	Identify       Method
 }
+
+const IdentifyName = "Identify" // auto-generated
 
 func (Service) IAmPlan()     {}
 func (Service) Kind() string { return "Service" }

--- a/services/errors.go
+++ b/services/errors.go
@@ -1,0 +1,19 @@
+package services
+
+// PkgPath is the fully-qualified name of this package.
+const PkgPath = "github.com/ipld/edelweiss/services"
+
+// ErrContext wraps context-related errors, like context cancellation.
+type ErrContext struct {
+	error
+}
+
+// ErrProto wraps protocol errors, like undecodable messages.
+type ErrProto struct {
+	error
+}
+
+// ErrService wraps service-level errors, produced by service implementations.
+type ErrService struct {
+	error
+}

--- a/services/errors.go
+++ b/services/errors.go
@@ -5,15 +5,27 @@ const PkgPath = "github.com/ipld/edelweiss/services"
 
 // ErrContext wraps context-related errors, like context cancellation.
 type ErrContext struct {
-	error
+	Cause error
+}
+
+func (e ErrContext) Error() string {
+	return e.Cause.Error()
 }
 
 // ErrProto wraps protocol errors, like undecodable messages.
 type ErrProto struct {
-	error
+	Cause error
+}
+
+func (e ErrProto) Error() string {
+	return e.Cause.Error()
 }
 
 // ErrService wraps service-level errors, produced by service implementations.
 type ErrService struct {
-	error
+	Cause error
+}
+
+func (e ErrService) Error() string {
+	return e.Cause.Error()
 }

--- a/test/harness.go
+++ b/test/harness.go
@@ -36,7 +36,7 @@ module test
 go 1.16
 
 require (
-	github.com/ipld/edelweiss 04fefef7007b598f1b46bb1618400c9fa81fd3a9
+	github.com/ipld/edelweiss d7bc07a0e79bb9f2dd82c7a0d95be31e0162350d
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/ipfs/go-cid v0.0.4
 )

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -42,6 +42,10 @@ func (TestService_ServerImpl) Method2(ctx context.Context, req *values.String, r
 	return nil
 }
 
+var testServiceIdentifyResult = &TestService_IdentifyResult{
+	Methods: []values.String{"Method1", "Method2"},
+}
+
 func TestRoundtrip(t *testing.T) {
 
 	s := httptest.NewServer(TestService_AsyncHandler(TestService_ServerImpl{}))
@@ -76,6 +80,17 @@ func TestRoundtrip(t *testing.T) {
 	// if *r2[1] != values.Float(4.56) {
 	// 	t.Fatalf("expecting 4.56, got %v", *r2[1])
 	// }
+
+	r3, err := c.Identify(ctx, &TestService_IdentifyArg{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r3) != 1 {
+		t.Fatalf("expecting 1 results, got %d", len(r3))
+	}
+	if !ipld.DeepEqual(r3[0], testServiceIdentifyResult) {
+		t.Fatalf("expecting #%v, got %v", testServiceIdentifyResult, r3[0])
+	}
 
 }`
 	RunGenTest(t, defs, testSrc)

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -21,23 +21,23 @@ func TestService(t *testing.T) {
 
 type TestService_ServerImpl struct{}
 
-func (TestService_ServerImpl) Method1(ctx context.Context, req *values.Int, respCh chan<- *values.Bool) error {
+func (TestService_ServerImpl) Method1(ctx context.Context, req *values.Int, respCh chan<- *TestService_Method1_AsyncResult) error {
 	go func() {
 		defer close(respCh)
 		var r1 values.Bool = true
-		respCh <- &r1
+		respCh <- &TestService_Method1_AsyncResult{ Resp: &r1 }
 	}()
 	return nil
 }
 
-func (TestService_ServerImpl) Method2(ctx context.Context, req *values.String, respCh chan<- *values.Float) error {
+func (TestService_ServerImpl) Method2(ctx context.Context, req *values.String, respCh chan<- *TestService_Method2_AsyncResult) error {
 	go func() {
 		defer close(respCh)
 		var r1 values.Float = 1.23
-		respCh <- &r1
+		respCh <- &TestService_Method2_AsyncResult{ Resp: &r1 }
 		// TODO: dagjson.Decode does not support multiple streaming values
 		// var r2 values.Float = 4.56
-		// respCh <- &r2
+		// respCh <- &TestService_Method2_AsyncResult{ Resp: &r2 }
 	}()
 	return nil
 }


### PR DESCRIPTION
Upgrades to RPC service generation to meet new IPFS routing API spec https://github.com/ipfs/specs/pull/272:
- [x] add error envelope to responses
- [x] add Request/Response suffix on method cases in call and return envelopes
- [x] change user facing method semantics to `Method(arg) (<-chan{ result | error }, error)`, both client and server
- [x] auto-generate Identify method
- [x] update example code