### PR TITLE
add default case to inductive type

### DIFF
--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -80,6 +80,38 @@ func TestInductiveAtCompileTime(t *testing.T) {
 	}
 }
 
+func TestInductiveWithDefaultAtCompileTime(t *testing.T) {
+	defs := defs.Defs{
+		defs.Named{
+			Name: "S1",
+			Type: defs.Inductive{
+				Cases: defs.Cases{
+					defs.Case{Name: "Int", Type: defs.Int{}},
+					defs.Case{Name: "Bool", Type: defs.Bool{}},
+				},
+				Default: defs.DefaultCase{
+					GoKeyName:   "DefaultKey",
+					GoValueName: "DefaultValue",
+					Type:        defs.Any{},
+				},
+			},
+		},
+	}
+	x := &GoPkgCodegen{
+		GoPkgDirPath: "",
+		GoPkgPath:    "test",
+		Defs:         defs,
+	}
+	goFile, err := x.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = goFile.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUnionAtCompileTime(t *testing.T) {
 	defs := defs.Defs{
 		defs.Named{

--- a/defs/inductive.go
+++ b/defs/inductive.go
@@ -1,7 +1,14 @@
 package defs
 
 type Inductive struct {
-	Cases Cases
+	Cases   Cases
+	Default DefaultCase
+}
+
+type DefaultCase struct {
+	GoKeyName   string
+	GoValueName string
+	Type        Def
 }
 
 func (Inductive) Kind() string {

--- a/plans/plans.go
+++ b/plans/plans.go
@@ -95,7 +95,14 @@ type Field struct {
 }
 
 type Inductive struct {
-	Cases Cases
+	Cases   Cases
+	Default DefaultCase
+}
+
+type DefaultCase struct {
+	GoKeyName   string
+	GoValueName string
+	Type        BuiltinOrRefPlan
 }
 
 func (Inductive) IAmPlan()     {}

--- a/test/values_test.go
+++ b/test/values_test.go
@@ -125,6 +125,56 @@ func TestInductiveAtRunTime(t *testing.T) {
 	}
 }
 
+func TestInductiveWithDefaultAtRunTime(t *testing.T) {
+	defs := []defs.Defs{
+		{
+			defs.Named{
+				Name: "UserInductive",
+				Type: defs.Inductive{
+					Cases: defs.Cases{
+						defs.Case{Name: "A", Type: defs.Int{}},
+						defs.Case{Name: "B", Type: defs.String{}},
+						defs.Case{Name: "C", Type: defs.Float{}},
+						defs.Case{Name: "D", Type: defs.Byte{}},
+						defs.Case{Name: "E", Type: defs.Char{}},
+					},
+					Default: defs.DefaultCase{
+						GoKeyName:   "DefaultKey",
+						GoValueName: "DefaultValue",
+						Type:        defs.Any{},
+					},
+				},
+			},
+		},
+	}
+	testSrc := `
+	var x1 UserInductive
+	var w values.Any
+	var y values.String = "abc"
+	w.Value = y
+	x1.DefaultKey = "default"
+	x1.DefaultValue = &w
+	buf, err := ipld.Encode(x1, dagjson.Encode)
+	if err != nil {
+		t.Fatalf("encoding (%v)", err)
+	}
+	var x2 UserInductive
+	n, err := ipld.Decode(buf, dagjson.Decode)
+	if err != nil {
+		t.Fatalf("decoding (%v)", err)
+	}
+	if err = x2.Parse(n); err != nil {
+		t.Fatalf("parsing (%v)", err)
+	}
+	if !ipld.DeepEqual(x1, x2) {
+		t.Errorf("ipld values are not equal")
+	}
+`
+	for _, d := range defs {
+		RunSingleGenTest(t, d, testSrc)
+	}
+}
+
 func TestUnionAtRunTime(t *testing.T) {
 	defs := []defs.Defs{
 		{defs.Named{


### PR DESCRIPTION
Add support for a _default_ case in inductive types. A default case is a case whose string key is not equal to any of the defined inductive cases' keys. When a default case is allowed, the user defines the acceptable value type for the default case (e.g. Any).