### PR TITLE
proxy synchronous service errors to client

### DIFF
--- a/blueprints/services/dagjson-over-http/server.go
+++ b/blueprints/services/dagjson-over-http/server.go
@@ -69,7 +69,8 @@ func (x GoServerImpl) GoDef() cg.Blueprint {
 		case env.{{.MethodName}} != nil:
 			ch, err := s.{{.MethodName}}({{.ContextBackground}}(), env.{{.MethodName}})
 			if err != nil {
-				{{.LoggerVar}}.Errorf("get p2p provider rejected request (%v)", err)
+				{{.LoggerVar}}.Errorf("service rejected request (%v)", err)
+				writer.Header()["Error"] = []string{err.Error()}
 				writer.WriteHeader(500)
 				return
 			}


### PR DESCRIPTION
User service implementations can generate both synchronous errors (immediately in response to a correctly decoded method call) and asynchronous error (as part of the multi-response sequence).

This PR ensures that synchronous errors are propagated to the client in a manner distinguished from asynchronous ones, so that the client can return the synchronous errors to the user synchronously (i.e. in the error result returned by the method call itself).