### PR TITLE
add cachable modifier to methods

### DIFF
--- a/blueprints/base/services.go
+++ b/blueprints/base/services.go
@@ -39,4 +39,5 @@ var (
 	EdelweissErrProto   = &cg.GoTypeRef{PkgPath: EdelweissServicesPkg, TypeName: "ErrProto"}
 	EdelweissErrService = &cg.GoTypeRef{PkgPath: EdelweissServicesPkg, TypeName: "ErrService"}
 	EdelweissErrSchema  = &cg.GoRef{PkgPath: EdelweissServicesPkg, Name: "ErrSchema"}
+	EdelweissETag       = &cg.GoRef{PkgPath: EdelweissServicesPkg, Name: "ETag"}
 )

--- a/blueprints/base/services.go
+++ b/blueprints/base/services.go
@@ -27,6 +27,7 @@ var (
 
 var (
 	IOReadCloser       = &cg.GoRef{PkgPath: "io", Name: "ReadCloser"}
+	IOWriter           = &cg.GoRef{PkgPath: "io", Name: "Writer"}
 	IOEOF              = &cg.GoRef{PkgPath: "io", Name: "EOF"}
 	IOErrUnexpectedEOF = &cg.GoRef{PkgPath: "io", Name: "ErrUnexpectedEOF"}
 	IOReadAll          = &cg.GoRef{PkgPath: "io", Name: "ReadAll"}

--- a/blueprints/base/values.go
+++ b/blueprints/base/values.go
@@ -41,6 +41,8 @@ var (
 	DAGJSONEncode        = cg.GoRef{PkgPath: "github.com/ipld/go-ipld-prime/codec/dagjson", Name: "Encode"}
 	DAGJSONDecode        = cg.GoRef{PkgPath: "github.com/ipld/go-ipld-prime/codec/dagjson", Name: "Decode"}
 	DAGJSONDecodeOptions = cg.GoTypeRef{PkgPath: "github.com/ipld/go-ipld-prime/codec/dagjson", TypeName: "DecodeOptions"}
+	DAGCBOREncode        = cg.GoRef{PkgPath: "github.com/ipld/go-ipld-prime/codec/dagcbor", Name: "Encode"}
+	DAGCBORDecode        = cg.GoRef{PkgPath: "github.com/ipld/go-ipld-prime/codec/dagcbor", Name: "Decode"}
 )
 
 var (

--- a/blueprints/services/dagjson-over-http/client.go
+++ b/blueprints/services/dagjson-over-http/client.go
@@ -50,6 +50,7 @@ func (x GoClientImpl) GoDef() cg.Blueprint {
 			"MethodReturn":       x.Lookup.LookupDepGoRef(m.Type.Return),
 			"MethodReturnAsync":  asyncResultRef,
 			"ProcessReturnAsync": processAsyncResultRef,
+			"MethodCachable":     cg.BlueBool(m.Cachable),
 			//
 			"DAGJSONEncode":             base.DAGJSONEncode,
 			"Context":                   base.Context,

--- a/blueprints/services/dagjson-over-http/client.go
+++ b/blueprints/services/dagjson-over-http/client.go
@@ -53,6 +53,7 @@ func (x GoClientImpl) GoDef() cg.Blueprint {
 			"MethodCachable":     cg.BlueBool(m.Cachable),
 			//
 			"DAGJSONEncode":             base.DAGJSONEncode,
+			"DAGCBOREncode":             base.DAGCBOREncode,
 			"Context":                   base.Context,
 			"ContextWithCancel":         base.ContextWithCancel,
 			"LoggerVar":                 loggerVar,
@@ -227,14 +228,25 @@ func (c *{{.Type}}) {{.AsyncMethodDecl}} {
 		{{.MethodName}}: req,
 	}
 
+	{{if .MethodCachable}}
+	buf, err := {{.IPLDEncode}}(envelope, {{.DAGCBOREncode}}) // XXX: apply binary encoding on top?
+	{{else}}
 	buf, err := {{.IPLDEncode}}(envelope, {{.DAGJSONEncode}})
+	{{end}}
 	if err != nil {
 		return nil, {{.Errorf}}("serializing DAG-JSON request: %w", err)
 	}
 
 	// encode request in URL
 	u := *c.endpoint
+	{{if .MethodCachable}}
+	q := {{.URLValues}}{}
+	q.Set("q", string(buf))
+	u.RawQuery = q.Encode()
+	httpReq, err := {{.HTTPNewRequestWithContext}}(ctx, "GET", u.String(), nil)
+	{{else}}
 	httpReq, err := {{.HTTPNewRequestWithContext}}(ctx, "POST", u.String(), {{.BytesNewReader}}(buf))
+	{{end}}
 	if err != nil {
 		return nil, err
 	}

--- a/blueprints/services/dagjson-over-http/server.go
+++ b/blueprints/services/dagjson-over-http/server.go
@@ -57,6 +57,7 @@ func (x GoServerImpl) GoDef() cg.Blueprint {
 			"IPLDEncodeStreaming": base.IPLDEncodeStreaming,
 			"DAGJSONEncode":       base.DAGJSONEncode,
 			"EdelweissString":     base.EdelweissString,
+			"EdelweissETag":       base.EdelweissETag,
 			"BytesBuffer":         base.BytesBuffer,
 			"HTTPFlusher":         base.HTTPFlusher,
 		}

--- a/blueprints/services/dagjson-over-http/server.go
+++ b/blueprints/services/dagjson-over-http/server.go
@@ -134,10 +134,16 @@ func (x GoServerImpl) GoDef() cg.Blueprint {
 					writer.WriteHeader(500)
 					return
 				}
-				writer.Header()["ETag"] = []string{etag}
-				writer.Write(result)
-				if f, ok := writer.({{.HTTPFlusher}}); ok {
-					f.Flush()
+				// if the request has an If-None-Match header, respond appropriately
+				ifNoneMatchValue := request.Header["If-None-Match"]
+				if len(ifNoneMatchValue) == 1 && ifNoneMatchValue[0] == etag {
+					writer.WriteHeader(304)
+				} else {
+					writer.Header()["ETag"] = []string{etag}
+					writer.Write(result)
+					if f, ok := writer.({{.HTTPFlusher}}); ok {
+						f.Flush()
+					}
 				}
 			}
 `,
@@ -293,10 +299,16 @@ func {{.AsyncHandler}}(s {{.Interface}}) {{.HTTPHandlerFunc}} {
 				writer.WriteHeader(500)
 				return
 			}
-			writer.Header()["ETag"] = []string{etag}
-			writer.Write(result)
-			if f, ok := writer.({{.HTTPFlusher}}); ok {
-				f.Flush()
+			// if the request has an If-None-Match header, respond appropriately
+			ifNoneMatchValue := request.Header["If-None-Match"]
+			if len(ifNoneMatchValue) == 1 && ifNoneMatchValue[0] == etag {
+				writer.WriteHeader(304)
+			} else {
+				writer.Header()["ETag"] = []string{etag}
+				writer.Write(result)
+				if f, ok := writer.({{.HTTPFlusher}}); ok {
+					f.Flush()
+				}
 			}
 `
 )

--- a/codegen/blueprint.go
+++ b/codegen/blueprint.go
@@ -14,6 +14,13 @@ type Blueprint interface {
 	Write(GoFileContext, io.Writer) error
 }
 
+type BlueBool bool
+
+func (x BlueBool) Write(ctx GoFileContext, w io.Writer) error {
+	_, err := fmt.Fprint(w, x)
+	return err
+}
+
 type BlueSlice []Blueprint
 
 func (x BlueSlice) Write(ctx GoFileContext, w io.Writer) error {
@@ -102,6 +109,8 @@ func (x T) Write(ctx GoFileContext, w io.Writer) error {
 
 func flattenBlueprint(ctx GoFileContext, b Blueprint) (Blueprint, error) {
 	switch t := b.(type) {
+	case BlueBool:
+		return t, nil
 	case BlueMap:
 		return flattenBlueMap(ctx, t)
 	case BlueSlice:

--- a/compile/stages.go
+++ b/compile/stages.go
@@ -262,6 +262,7 @@ func provisionService(p *genPlan, named string, s defs.Service) (plans.Plan, err
 					},
 				},
 			},
+			Cachable: true,
 		},
 	}, s.Methods...)
 
@@ -283,7 +284,7 @@ func provisionService(p *genPlan, named string, s defs.Service) (plans.Plan, err
 		if m.Name == plans.IdentifyName {
 			plan.Identify = plans.Method{Name: plans.IdentifyName, Type: fn}
 		}
-		plan.Methods[i] = plans.Method{Name: m.Name, Type: fn}
+		plan.Methods[i] = plans.Method{Name: m.Name, Type: fn, Cachable: m.Cachable}
 		callCases[i] = plans.Case{Name: m.Name + "Request", GoName: m.Name, Type: argRef}
 		returnCases[i] = plans.Case{Name: m.Name + "Response", GoName: m.Name, Type: returnRef}
 	}

--- a/defs/service.go
+++ b/defs/service.go
@@ -10,8 +10,9 @@ func (Service) Kind() string {
 }
 
 type Method struct {
-	Name string
-	Type Fn
+	Name     string
+	Type     Fn
+	Cachable bool
 }
 
 type Methods []Method

--- a/defs/types_test.go
+++ b/defs/types_test.go
@@ -30,8 +30,8 @@ func TestServiceDef(t *testing.T) {
 		Named{"RoutingService",
 			Service{
 				Methods: Methods{
-					Method{"Put1",
-						Fn{
+					Method{Name: "Put1",
+						Type: Fn{
 							Arg: Ref{"PutArgs"},
 							Return: Union{
 								Cases: Cases{
@@ -41,8 +41,8 @@ func TestServiceDef(t *testing.T) {
 							},
 						},
 					},
-					Method{"Put2",
-						Fn{
+					Method{Name: "Put2",
+						Type: Fn{
 							Arg: Tuple{
 								Slots: Slots{Ref{"Key"}, Any{}},
 							},
@@ -54,8 +54,8 @@ func TestServiceDef(t *testing.T) {
 							},
 						},
 					},
-					Method{"Get",
-						Fn{
+					Method{Name: "Get",
+						Type: Fn{
 							Arg: Ref{"Key"},
 							Return: Union{
 								Cases: Cases{
@@ -77,8 +77,8 @@ func TestServiceDef2(t *testing.T) {
 		Named{"DelegatedRoutingService",
 			Service{
 				Methods: Methods{
-					Method{"PutP2PProvider", Fn{Arg: Ref{"PutP2PProviderRequest"}, Return: Ref{"PutP2PProviderResponse"}}},
-					Method{"GetP2PProviders", Fn{Arg: Ref{"GetP2PProvidersRequest"}, Return: Ref{"GetP2PProvidersResponse"}}},
+					Method{Name: "PutP2PProvider", Type: Fn{Arg: Ref{"PutP2PProviderRequest"}, Return: Ref{"PutP2PProviderResponse"}}},
+					Method{Name: "GetP2PProviders", Type: Fn{Arg: Ref{"GetP2PProvidersRequest"}, Return: Ref{"GetP2PProvidersResponse"}}},
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.17.0
+	github.com/multiformats/go-multihash v0.1.0
 )
 
 require (
@@ -19,7 +20,6 @@ require (
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
-	github.com/multiformats/go-multihash v0.1.0 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect

--- a/plans/service.go
+++ b/plans/service.go
@@ -16,6 +16,7 @@ func (Service) Kind() string { return "Service" }
 type Methods []Method
 
 type Method struct {
-	Name string
-	Type Fn
+	Name     string
+	Type     Fn
+	Cachable bool
 }

--- a/services/etag.go
+++ b/services/etag.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"github.com/multiformats/go-multihash"
+)
+
+// ETag computes a strong HTTP ETag string for a block of bytes.
+func ETag(b []byte) (string, error) {
+	mh, err := multihash.Sum(b, multihash.SHA1, -1)
+	if err != nil {
+		return "", err
+	}
+	return mh.B58String(), nil
+}

--- a/test/harness.go
+++ b/test/harness.go
@@ -39,7 +39,7 @@ module test
 go 1.16
 
 require (
-	github.com/ipld/edelweiss 625345fdc3f8a74a9cf356a7b2161ba81eace99b
+	github.com/ipld/edelweiss 3d6cbc4d10f0f07421d8d7f3fcf71b8fe5f2d4d7
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/ipfs/go-cid v0.0.4
 )

--- a/test/harness.go
+++ b/test/harness.go
@@ -39,7 +39,7 @@ module test
 go 1.16
 
 require (
-	github.com/ipld/edelweiss 3d6cbc4d10f0f07421d8d7f3fcf71b8fe5f2d4d7
+	github.com/ipld/edelweiss 1d3e560fd45e1956f44430ccece346737eb2c593
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/ipfs/go-cid v0.0.4
 )

--- a/test/harness.go
+++ b/test/harness.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ipld/edelweiss/compile"
@@ -32,18 +34,27 @@ func RunGenTest(t *testing.T, defs defs.Defs, testSrc string) {
 	// defer os.RemoveAll(dir)
 	fmt.Printf("generating test in %s\n", dir)
 
+	// find module root of the test
+	modFile, err := exec.Command("go", "env", "GOMOD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	modRoot := filepath.Dir(strings.TrimSpace(string(modFile)))
+
 	// create go.mod
-	goModSrc := `
+	goModSrc := fmt.Sprintf(`
 module test
 
 go 1.16
 
 require (
-	github.com/ipld/edelweiss 1d3e560fd45e1956f44430ccece346737eb2c593
+	github.com/ipld/edelweiss v0.0.1
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/ipfs/go-cid v0.0.4
 )
-`
+replace github.com/ipld/edelweiss v0.0.1 => %s
+`, modRoot)
+
 	if err := os.WriteFile(path.Join(dir, "go.mod"), []byte(goModSrc), 0644); err != nil {
 		t.Fatalf("creating go.mod (%v)", err)
 	}


### PR DESCRIPTION
Addresses https://github.com/ipfs/specs/issues/282 and https://github.com/ipfs/specs/pull/287.

[x] add cachable modifier to method definitions
[x] use `GET` for cachable methods, `POST` for others
[x] servers deny `GET` requests for non-cachable methods
[x] servers generate `ETag` for cachable methods
[x] servers support `If-None-Match` for cachable methods
